### PR TITLE
Handling buffer model change gracefully

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -30,6 +30,7 @@ BufferMgr::BufferMgr(DBConnector *cfgDb, DBConnector *applDb, string pg_lookup_f
         m_applBufferEgressProfileListTable(applDb, APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME)
 {
     readPgProfileLookupFile(pg_lookup_file);
+    dynamic_buffer_model = false;
 }
 
 //# speed, cable, size,    xon,  xoff, threshold,  xon_offset
@@ -273,12 +274,62 @@ void BufferMgr::doBufferTableTask(Consumer &consumer, ProducerStateTable &applTa
     }
 }
 
+void BufferMgr::doBufferMetaTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string key = kfvKey(t);
+
+        string op = kfvOp(t);
+        if (op == SET_COMMAND)
+        {
+            vector<FieldValueTuple> fvVector;
+
+            for (auto i : kfvFieldsValues(t))
+            {
+                if (fvField(i) == "buffer_model")
+                {
+                    if (fvValue(i) == "dynamic")
+                    {
+                        dynamic_buffer_model = true;
+                    }
+                    else
+                    {
+                        dynamic_buffer_model = false;
+                    }
+                    break;
+                }
+            }
+        }
+        else if (op == DEL_COMMAND)
+        {
+            dynamic_buffer_model = false;
+        }
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
 void BufferMgr::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
     string table_name = consumer.getTableName();
 
+    if (table_name == CFG_DEVICE_METADATA_TABLE_NAME)
+    {
+        doBufferMetaTask(consumer);
+        return;
+    }
+
+    if (dynamic_buffer_model)
+    {
+         SWSS_LOG_DEBUG("Dynamic buffer model enabled. Skipping further processing");
+         return;
+    }
     if (table_name == CFG_BUFFER_POOL_TABLE_NAME)
     {
         doBufferTableTask(consumer, m_applBufferPoolTable);

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -50,6 +50,7 @@ private:
     ProducerStateTable m_applBufferEgressProfileListTable;
 
     bool m_pgfile_processed;
+    bool dynamic_buffer_model;
 
     pg_profile_lookup_t m_pgProfileLookup;
     port_cable_length_t m_cableLenLookup;
@@ -63,6 +64,7 @@ private:
     void transformSeperator(std::string &name);
 
     void doTask(Consumer &consumer);
+    void doBufferMetaTask(Consumer &consumer);
 };
 
 }

--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -195,7 +195,8 @@ int main(int argc, char **argv)
                 CFG_BUFFER_PG_TABLE_NAME,
                 CFG_BUFFER_QUEUE_TABLE_NAME,
                 CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
-                CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+                CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME,
+                CFG_DEVICE_METADATA_TABLE_NAME
             };
             cfgOrchList.emplace_back(new BufferMgr(&cfgDb, &applDb, pg_lookup_file, cfg_buffer_tables));
         }

--- a/tests/test_buffer_mode.py
+++ b/tests/test_buffer_mode.py
@@ -1,7 +1,20 @@
 import pytest
+import time
 
 class TestBufferModel(object):
     def test_bufferModel(self, dvs, testlog):
         config_db = dvs.get_config_db()
         metadata = config_db.get_entry("DEVICE_METADATA", "localhost")
         assert metadata["buffer_model"] == "traditional"
+
+    def test_update_bufferModel(self, dvs, testlog):
+        config_db = dvs.get_config_db()
+        app_db = dvs.get_app_db()
+        keys = app_db.get_keys("BUFFER_POOL_TABLE")
+        num_keys =  len(keys)
+        fvs = {'buffer_model' : 'dynamic'}
+        config_db.update_entry("DEVICE_METADATA", "localhost", fvs)
+        fvs = {'mode':'dynamic', 'type':'egress'}
+        config_db.update_entry("BUFFER_POOL", "temp_pool", fvs)
+        time.sleep(2)
+        app_db.wait_for_n_keys("BUFFER_POOL_TABLE", num_keys)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Handled buffer model changes gracefully

**Why I did it**
When config qos reload is given in platforms with dynamic buffer model, swss restart is required. However, if swss is not restarted the buffermgrd will stay in static model and will program the orchagent with 'size' field not set in buffer pool due to dynamic mode checks in jinja2 template. This will result in orchagent calling SAI without SAI_BUFFER_POOL_ATTR_SIZE which is mandatory attribute.
Since this results in a SAI create API failure, it will result in orchagent crash.
So when the mode is changed to dynamic, buffermgrd will not process any configurations when running in static mode.

**How I verified it**
Added UT. Manually verified that config qos reload doesn't crash.

**Details if related**
