### PR TITLE
[vlanmgr]Fix for STATE_DB port check logic

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -7,6 +7,7 @@
 #include "tokenize.h"
 #include "shellcmd.h"
 #include "warm_restart.h"
+#include <swss/redisutility.h>
 
 using namespace std;
 using namespace swss;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated checks for PORT entry in STATE_DB in vlanmgrd additionally check for presence of "state" attribute.


**Why I did it**
Prior to recent commits for PORT auto-negotiation, 3 daemons in cfgmgr (portmgrd, teammgrd, and intfmgrd) would not allow configuration to proceed for a specific PORT until portsyncd detected the presence of the kernel device (EthernetN) associated with the PORT and created the associated entry for the PORT in the STATE_DB with attribute "state" and value "ok".
With recent commits for PORT auto-negotiation, this logic is now broken due to creation of PORT entry in the STATE_DB by PortsOrch with only "supported_speed" attribute.



**How I verified it**
This leads to the issue where vlanmgrd might try to access the port even without it created
Oct 21 07:51:42.121276 arc-switch1025 ERR swss#vlanmgrd: :- main: Runtime error: /bin/bash -c "/sbin/ip link set "Ethernet10" master Bridge && /sbin/bridge vlan del vid 1 dev "Ethernet10" && /sbin/bridge vlan add vid 1000 dev "Ethernet10" pvid untagged" :
Oct 21 07:51:42.122339 arc-switch1025 INFO swss#/supervisord: vlanmgrd Cannot find device "Ethernet10"


**Details if related**
