### PR TITLE
[VNET]Fixing nexthop group delete during route change

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -949,7 +949,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
             NextHopGroupKey nhg = it_route->second;
             if(--syncd_nexthop_groups_[vnet][nhg].ref_count == 0)
             {
-                if (nexthops.getSize() > 1)
+                if (nhg.getSize() > 1)
                 {
                     removeNextHopGroup(vnet, nhg, vrf_obj);
                 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When a VNET with nexthop group is replaced with a single nexthop the following error is seen in the test
Mar 23 14:08:30.801303 r-leopard-01 ERR swss#orchagent: :- doTask: Parse error: Error converting 100.0.5.1@@0@00:00:00:00:00:00,100.0.6.1@@0@00:00:00:00:00:00 to NextHop


**Why I did it**
The issue is due to the reason that in the removing existing nexthop flow, instead of looking at size of existing nexthop to determine if it is a group or single NH, the new nexthop is considered which leads to incorrect classification in the above scenario.
Modified the code to consider the existing nhg instead of new ones.


**How I verified it**
Verified the case by testing the above scenario.

**Details if related**
