### PR TITLE
[BFD]Registering BFD state change callback during session creation

### DIFF
--- a/orchagent/bfdorch.h
+++ b/orchagent/bfdorch.h
@@ -26,12 +26,15 @@ private:
     uint32_t bfd_gen_id(void);
     uint32_t bfd_src_port(void);
 
+    bool register_bfd_state_change_notification(void);
+
     std::map<std::string, sai_object_id_t> bfd_session_map;
     std::map<sai_object_id_t, BfdUpdate> bfd_session_lookup;
 
     swss::Table m_stateBfdSessionTable;
 
     swss::NotificationConsumer* m_bfdStateNotificationConsumer;
+    bool register_state_change_notif;
 };
 
 #endif /* SWSS_BFDORCH_H */

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -478,10 +478,6 @@ int main(int argc, char **argv)
     attr.value.ptr = (void *)on_port_state_change;
     attrs.push_back(attr);
 
-    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
-    attr.value.ptr = (void *)on_bfd_session_state_change;
-    attrs.push_back(attr);
-
     attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
     attr.value.ptr = (void *)on_switch_shutdown_request;
     attrs.push_back(attr);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Register BFD callback during the BFD session creation flow


**Why I did it**
BFD session callback is required to get state changes from SAI and there by remove or add endpoints. However not all vendors support it. So moved it from switch initialization and set it during first session creation

**How I verified it**
Verified it manually with BFD show command which also relies on BFD session change notifications


**Details if related**
