### PR TITLE
[EVPN]Modified tunnel creation logic when creating tunnel in VRF-VNI map creation flow

### DIFF
--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -149,7 +149,6 @@ public:
         return active_;
     }
 
-    bool createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl=0);
     sai_object_id_t addEncapMapperEntry(sai_object_id_t obj, uint32_t vni, 
                                         tunnel_map_type_t type=TUNNEL_MAP_T_VIRTUAL_ROUTER);
     sai_object_id_t addDecapMapperEntry(sai_object_id_t obj, uint32_t vni,

--- a/tests/test_evpn_l3_vxlan_p2mp.py
+++ b/tests/test_evpn_l3_vxlan_p2mp.py
@@ -37,11 +37,11 @@ class TestL3VxlanP2MP(object):
         vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
         vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
 
-        print ("\tCreate Vlan-VNI map and VRF-VNI map")
-        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
-
         vxlan_obj.create_vrf(dvs, "Vrf-RED")
         vxlan_obj.create_vxlan_vrf_tunnel_map(dvs, 'Vrf-RED', '1000')
+
+        print ("\tCreate Vlan-VNI map and VRF-VNI map")
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
 
         print ("\tTesting VRF-VNI map in APP DB")
         vlanlist = ['100']


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
```
To fix issue https://github.com/Azure/sonic-buildimage/issues/11428
```
Modified the logic of tunnel map creation to create tunnel with tunnel map for vlan-vni map in addition to vrf-vni map when tunnel is created first time in the VRF-VNI map processing flow.


**Why I did it**
During the configuration phase when VRF-VNI map arrives before VLAN-VNI map, the tunnel is created without a tunnel map for vlan-vni membership. This is problematic when VLAN to VNI map arrives later, tunnel map entry cannot be created since the tunnel map doesn't exist and its a create only attribute in SAI.

**How I verified it**
Modified UT to add VRF-VNI map first and VLAN-VLAN map later

**Details if related**
