### PR TITLE
[BFD]Clean up state_db BFD entries on swss restart

### DIFF
--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -59,6 +59,17 @@ BfdOrch::BfdOrch(DBConnector *db, string tableName, TableConnector stateDbBfdSes
     DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
     m_bfdStateNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
     auto bfdStateNotificatier = new Notifier(m_bfdStateNotificationConsumer, this, "BFD_STATE_NOTIFICATIONS");
+
+    // Clean up state database BFD entries
+    vector<string> keys;
+
+    m_stateBfdSessionTable.getKeys(keys);
+
+    for (auto alias : keys)
+    {
+        m_stateBfdSessionTable.del(alias);
+    }
+
     Orch::addExecutor(bfdStateNotificatier);
     register_state_change_notif = false;
 }

--- a/tests/test_bfd.py
+++ b/tests/test_bfd.py
@@ -464,3 +464,23 @@ class TestBfd(object):
         self.adb.wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION", session3)
         self.remove_bfd_session(key4)
         self.adb.wait_for_deleted_entry("ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION", session4)
+
+    def test_bfd_state_db_clear(self, dvs):
+        self.setup_db(dvs)
+
+        bfdSessions = self.get_exist_bfd_session()
+
+        # Create BFD session
+        fieldValues = {"local_addr": "10.0.0.1", "type": "demand_active"}
+        self.create_bfd_session("default:default:10.0.0.2", fieldValues)
+        self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_BFD_SESSION", len(bfdSessions) + 1)
+
+        # Checked created BFD session in ASIC_DB
+        createdSessions = self.get_exist_bfd_session() - bfdSessions
+        assert len(createdSessions) == 1
+        dvs.stop_swss()
+        dvs.start_swss()
+
+        time.sleep(5)
+        keys = self.sdb.get_keys("BFD_SESSION_TABLE")
+        assert len(keys) == 0


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Clean up BFD state_db entries during BFD orch initialization

**Why I did it**
To avoid having stale state_db entries after config reload.

**How I verified it**
Added UT to verify it.

**Details if related**
