### PR TITLE
[sai_failure_dump]Invoking dump during SAI failure

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -126,6 +126,8 @@ void syncd_apply_view()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to notify syncd APPLY_VIEW %d", status);
+        requestSaiFailureDump();
+        abort();
         exit(EXIT_FAILURE);
     }
 }
@@ -603,7 +605,8 @@ int main(int argc, char **argv)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create a switch, rv:%d", status);
-        exit(EXIT_FAILURE);
+        requestSaiFailureDump();
+        abort();
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
@@ -634,7 +637,8 @@ int main(int argc, char **argv)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to get MAC address from switch, rv:%d", status);
-                exit(EXIT_FAILURE);
+                requestSaiFailureDump();
+                abort();
             }
             else
             {
@@ -649,7 +653,8 @@ int main(int argc, char **argv)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Fail to get switch virtual router ID %d", status);
-            exit(EXIT_FAILURE);
+            requestSaiFailureDump();
+            abort();
         }
 
         gVirtualRouterId = attr.value.oid;
@@ -691,7 +696,8 @@ int main(int argc, char **argv)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create underlay router interface %d", status);
-            exit(EXIT_FAILURE);
+            requestSaiFailureDump();
+            abort();
         }
 
         SWSS_LOG_NOTICE("Created underlay router interface ID %" PRIx64, gUnderlayIfId);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -675,6 +675,7 @@ void OrchDaemon::flush()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to flush redis pipeline %d", status);
+        requestSaiFailureDump();
         abort();
     }
 }
@@ -976,3 +977,4 @@ bool FabricOrchDaemon::init()
 
     return true;
 }
+

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -496,6 +496,7 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    requestSaiFailureDump();
                     abort();
             }
             break;
@@ -514,6 +515,7 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    requestSaiFailureDump();
                     abort();
             }
         default:
@@ -525,6 +527,7 @@ task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, vo
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
                                 sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    requestSaiFailureDump();
                     abort();
             }
     }
@@ -566,6 +569,7 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
                 default:
                     SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                             sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    requestSaiFailureDump();
                     abort();
             }
         case SAI_API_TUNNEL:
@@ -578,11 +582,13 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
                 default:
                     SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                             sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    requestSaiFailureDump();
                     abort();
             }
         default:
             SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            requestSaiFailureDump();
             abort();
     }
 
@@ -611,6 +617,7 @@ task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, vo
         default:
             SWSS_LOG_ERROR("Encountered failure in remove operation, exiting orchagent, SAI API: %s, status: %s",
                         sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            requestSaiFailureDump();
             abort();
     }
     return task_need_retry;
@@ -662,4 +669,19 @@ bool parseHandleSaiStatusFailure(task_process_status status)
             SWSS_LOG_WARN("task_process_status %d is not expected in parseHandleSaiStatusFailure", status);
     }
     return true;
+}
+
+/* Request redis to invoke SAI failure dump*/
+void requestSaiFailureDump()
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+    attr.value.s32 =  SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP;
+    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to take sai failure dump %d", status);
+    }
 }

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -18,4 +18,4 @@ task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void 
 task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 bool parseHandleSaiStatusFailure(task_process_status status);
-
+void requestSaiFailureDump();

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -9,11 +9,14 @@
 #include "notifier.h"
 #define private public
 #include "pfcactionhandler.h"
+#include <sys/mman.h>
+
 #undef private
 
 #include <sstream>
 
 extern redisReply *mockReply;
+
 
 namespace portsorch_test
 {
@@ -21,6 +24,8 @@ namespace portsorch_test
 
     sai_port_api_t ut_sai_port_api;
     sai_port_api_t *pold_sai_port_api;
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
 
     bool not_support_fetching_fec;
     vector<sai_port_fec_mode_t> mock_port_fec_modes = {SAI_PORT_FEC_MODE_RS, SAI_PORT_FEC_MODE_FC};
@@ -66,7 +71,26 @@ namespace portsorch_test
             _sai_set_port_fec_count++;
             _sai_port_fec_mode = attr[0].value.s32;
         }
+        else if (attr[0].id == SAI_PORT_ATTR_AUTO_NEG_MODE)
+        {
+            /* Simulating failure case */
+            return SAI_STATUS_FAILURE;
+        }
         return pold_sai_port_api->set_port_attribute(port_id, attr);
+    }
+
+    uint32_t *_sai_syncd_notifications_count;
+    int32_t *_sai_syncd_notification_event;
+    sai_status_t _ut_stub_sai_set_switch_attribute(
+        _In_ sai_object_id_t switch_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD)
+        {
+            *_sai_syncd_notifications_count =+ 1;
+            *_sai_syncd_notification_event = attr[0].value.s32;
+        }
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
     }
 
     void _hook_sai_port_api()
@@ -81,6 +105,19 @@ namespace portsorch_test
     void _unhook_sai_port_api()
     {
         sai_port_api = pold_sai_port_api;
+    }
+
+    void _hook_sai_switch_api()
+    {
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
     }
 
     sai_queue_api_t ut_sai_queue_api;
@@ -472,6 +509,53 @@ namespace portsorch_test
         mock_port_fec_modes = old_mock_port_fec_modes;
         _unhook_sai_port_api();
     }
+
+    TEST_F(PortsOrchTest, PortTestSAIFailureHandling)
+    {
+        _hook_sai_port_api();
+        _hook_sai_switch_api();
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+        std::deque<KeyOpFieldsValuesTuple> entries;
+
+        not_support_fetching_fec = false;
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+
+        // Apply configuration :
+        //  create ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        _sai_syncd_notifications_count = (uint32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        _sai_syncd_notification_event = (int32_t*)mmap(NULL, sizeof(int), PROT_READ | PROT_WRITE,
+                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        *_sai_syncd_notifications_count = 0;
+
+        entries.push_back({"Ethernet0", "SET",
+                           {
+                               {"autoneg", "on"}
+                           }});
+        auto consumer = dynamic_cast<Consumer *>(gPortsOrch->getExecutor(APP_PORT_TABLE_NAME));
+        consumer->addToSync(entries);
+        ASSERT_DEATH({static_cast<Orch *>(gPortsOrch)->doTask();}, "");
+
+        ASSERT_EQ(*_sai_syncd_notifications_count, 1);
+        ASSERT_EQ(*_sai_syncd_notification_event, SAI_REDIS_NOTIFY_SYNCD_INVOKE_DUMP);
+        _unhook_sai_port_api();
+        _unhook_sai_switch_api();
+    }
+
 
     TEST_F(PortsOrchTest, PortReadinessColdBoot)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added logic to invoke SAI failure dump during any SAI programming failure before invoking abort.

**Why I did it**
To collect necessary dumps in problem state in syncd before abort is called and all processes restarts

**How I verified it**
Manual verification. Added UT to cover abort scenario as well.

**Details if related**
