### PR TITLE
[EVPN]Handling race condition when remote VNI arrives before tunnel map entry

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -2349,10 +2349,21 @@ bool EvpnRemoteVnip2pOrch::addOperation(const Request& request)
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunnelPort, vlanPort;
+    VxlanTunnelMapOrch* vxlan_tun_map_orch = gDirectory.get<VxlanTunnelMapOrch*>();
+    std::string vniVlanMapName;
+    uint32_t tmp_vlan_id = 0;
+    sai_object_id_t tnl_map_entry_id = SAI_NULL_OBJECT_ID;
 
     if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
+        return false;
+    }
+
+    /* Remote end point can be added only after local VLAN to VNI map gets created */
+    if (!vxlan_tun_map_orch->isVniVlanMapExists(vni_id, vniVlanMapName, &tnl_map_entry_id, &tmp_vlan_id))
+    {
+        SWSS_LOG_WARN("Vxlan tunnel map is not created for vni:%d", vni_id);
         return false;
     }
 
@@ -2492,6 +2503,11 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     }
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    VxlanTunnelMapOrch* vxlan_tun_map_orch = gDirectory.get<VxlanTunnelMapOrch*>();
+    std::string vniVlanMapName;
+    uint32_t tmp_vlan_id = 0;
+    sai_object_id_t tnl_map_entry_id = SAI_NULL_OBJECT_ID;
+
     Port tunnelPort, vlanPort;
     auto vtep_ptr = evpn_orch->getEVPNVtep();
     if (!vtep_ptr)
@@ -2504,6 +2520,13 @@ bool EvpnRemoteVnip2mpOrch::addOperation(const Request& request)
     if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
+        return false;
+    }
+
+    /* Remote end point can be added only after local VLAN to VNI map gets created */
+    if (!vxlan_tun_map_orch->isVniVlanMapExists(vni_id, vniVlanMapName, &tnl_map_entry_id, &tmp_vlan_id))
+    {
+        SWSS_LOG_WARN("Vxlan tunnel map is not created for vni: %d", vni_id);
         return false;
     }
 

--- a/tests/test_evpn_tunnel.py
+++ b/tests/test_evpn_tunnel.py
@@ -59,6 +59,9 @@ class TestVxlanOrch(object):
         vnilist = ['1000', '1001', '1002']
 
         vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.create_vlan1(dvs,"Vlan100")
+        vxlan_obj.create_vlan1(dvs,"Vlan101")
+        vxlan_obj.create_vlan1(dvs,"Vlan102")
         vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
         vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
@@ -159,5 +162,48 @@ class TestVxlanOrch(object):
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
         print("Testing SIP Tunnel Deletion")
+        vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
+        vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6')
+
+    def test_delayed_vlan_vni_map(self, dvs, testlog):
+        vxlan_obj = self.get_vxlan_obj()
+
+        tunnel_name = 'tunnel_2'
+        map_name = 'map_1000_100'
+        map_name_1 = 'map_1001_101'
+        vlanlist = ['100']
+        vnilist = ['1000']
+
+        vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.create_vlan1(dvs,"Vlan100")
+        vxlan_obj.create_vlan1(dvs,"Vlan101")
+
+        vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, tunnel_map_entry_count = 1)
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+
+        vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
+
+        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7', '1001')
+        vxlan_obj.check_vxlan_dip_tunnel_not_created(dvs, tunnel_name, '6.6.6.6', '7.7.7.7')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
+
+        print("Testing VLAN 101 extension")
+        vxlan_obj.check_vxlan_dip_tunnel(dvs, tunnel_name, '6.6.6.6', '7.7.7.7')
+        vxlan_obj.check_vlan_extension(dvs, '101', '7.7.7.7')
+
+        print("Testing Vlan Extension removal")
+        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7')
+        vxlan_obj.check_vlan_extension_delete(dvs, '101', '7.7.7.7')
+        vxlan_obj.check_vxlan_dip_tunnel_delete(dvs, '7.7.7.7')
+
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
+        vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
+
+        print("Testing SIP Tunnel Deletion")
+        vxlan_obj.remove_evpn_nvo(dvs, 'nvo1')
         vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
         vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6')

--- a/tests/test_evpn_tunnel_p2mp.py
+++ b/tests/test_evpn_tunnel_p2mp.py
@@ -57,6 +57,9 @@ class TestVxlanOrchP2MP(object):
         vnilist = ['1000', '1001', '1002']
 
         vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.create_vlan1(dvs,"Vlan100")
+        vxlan_obj.create_vlan1(dvs,"Vlan101")
+        vxlan_obj.create_vlan1(dvs,"Vlan102")
         vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
         vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
@@ -116,6 +119,47 @@ class TestVxlanOrchP2MP(object):
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_2, '1002', 'Vlan102')
+        vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
+
+        print("Testing SIP Tunnel Deletion")
+        vxlan_obj.remove_evpn_nvo(dvs, 'nvo1')
+        vxlan_obj.remove_vxlan_tunnel(dvs, tunnel_name)
+        vxlan_obj.check_vxlan_sip_tunnel_delete(dvs, tunnel_name, '6.6.6.6', ignore_bp=False)
+
+    def test_delayed_vlan_vni_map(self, dvs, testlog):
+        vxlan_obj = self.get_vxlan_obj()
+
+        tunnel_name = 'tunnel_2'
+        map_name = 'map_1000_100'
+        map_name_1 = 'map_1001_101'
+        vlanlist = ['100']
+        vnilist = ['1000']
+
+        vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.create_vlan1(dvs,"Vlan100")
+        vxlan_obj.create_vlan1(dvs,"Vlan101")
+
+        vxlan_obj.create_vxlan_tunnel(dvs, tunnel_name, '6.6.6.6')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+
+        vxlan_obj.check_vxlan_sip_tunnel(dvs, tunnel_name, '6.6.6.6', vlanlist, vnilist, ignore_bp=False, tunnel_map_entry_count = 1)
+        vxlan_obj.check_vxlan_tunnel_map_entry(dvs, tunnel_name, vlanlist, vnilist)
+
+        vxlan_obj.create_evpn_nvo(dvs, 'nvo1', tunnel_name)
+
+        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7', '1001')
+        vxlan_obj.check_vlan_extension_not_created_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+        vxlan_obj.create_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
+
+        print("Testing VLAN 101 extension")
+        vxlan_obj.check_vlan_extension_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+
+        print("Testing Vlan Extension removal")
+        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan101', '7.7.7.7')
+        vxlan_obj.check_vlan_extension_delete_p2mp(dvs, '101', '6.6.6.6', '7.7.7.7')
+
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
+        vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
         vxlan_obj.check_vxlan_tunnel_map_entry_delete(dvs, tunnel_name, vlanlist, vnilist)
 
         print("Testing SIP Tunnel Deletion")


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added check in remote VNI add to ensure vxlan tunnel map is created before adding the remote.

**Why I did it**
In some race conditions, the VXLAN_REMOTE_VNI_TABLE arrives before VXLAN_TUNNEL_MAP_TABLE. The below log shows race condition as for VNI 500101 is set seen before vxlan tunnel map entry.

2023-01-18.09:35:21.223861|VXLAN_TUNNEL_MAP_TABLE:vtep101032:map_500100_Vlan100|SET|vlan:Vlan100|vni:500100
2023-01-18.09:35:21.326760|VXLAN_FDB_TABLE:Vlan101:aa:e9:21:5a:48:3b|SET|remote_vtep:30.0.0.2|type:dynamic|vni:500101
2023-01-18.09:35:21.327053|VXLAN_FDB_TABLE:Vlan100:5e:3d:f7:1e:93:f6|SET|remote_vtep:30.0.0.2|type:dynamic|vni:500100
2023-01-18.09:35:21.327079|VXLAN_FDB_TABLE:Vlan100:2e:a1:55:f6:59:2e|SET|remote_vtep:40.0.0.3|type:dynamic|vni:500100
2023-01-18.09:35:21.328590|VXLAN_REMOTE_VNI_TABLE:Vlan100:30.0.0.2|SET|vni:500100
2023-01-18.09:35:21.328643|VXLAN_REMOTE_VNI_TABLE:Vlan100:40.0.0.3|SET|vni:500100
2023-01-18.09:35:21.328768|VXLAN_REMOTE_VNI_TABLE:Vlan101:30.0.0.2|SET|vni:500101

This results in SAI failure as below
Jan 18 11:35:21.450681 r-alligator-04 ERR syncd#SDK: [TUNNEL.ERR] Could not find the entry in the tunnel entries map
Jan 18 11:35:21.450801 r-alligator-04 ERR syncd#SDK: [TUNNEL.ERR] Failed to get from tunnel[0x08c00000] entry with FID 101 , err = Entry Not Found
Jan 18 11:35:21.450873 r-alligator-04 ERR syncd#SDK: [FDB_FLOOD.ERR] Failed to get tunnel mapping from fid (101)
Jan 18 11:35:21.450943 r-alligator-04 ERR syncd#SDK: [FDB_FLOOD.ERR] Failed to set flood_vector to fid (101)
Jan 18 11:35:21.451108 r-alligator-04 ERR syncd#SDK: [CORE_API.ERR] Failed to set fdb flood params, FDB module, return message: [Entry Not Found]
Jan 18 11:35:21.451182 r-alligator-04 ERR syncd#SDK: [SAI_L2MC_GROUP.ERR] mlnx_sai_l2mcgroup.c[853]- mlnx_l2mc_group_fid_uc_bc_flood_ctrl_update: Failed to SET ports to fid 101 flood set - Entry Not Found.
Jan 18 11:35:21.451367 r-alligator-04 ERR swss#orchagent: :- create: create status: SAI_STATUS_ITEM_NOT_FOUND
Jan 18 11:35:21.451501 r-alligator-04 ERR swss#orchagent: :- addVlanFloodGroups: Failed to create l2mc group member for adding tunnel 30.0.0.2 to vlan 101
Jan 18 11:35:21.451656 r-alligator-04 ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, exiting orchagent, SAI API: SAI_API_L2MC_GROUP, status: SAI_STATUS_ITEM_NOT_FOUND
Jan 18 11:35:21.451863 r-alligator-04 ERR syncd#SDK: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_ITEM_NOT_FOUND


**How I verified it**
Added UT to verify it.

**Details if related**
