### PR TITLE
[EVPN]Fixing nexthop group delete when multiple routes point to the nexthop group

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2214,10 +2214,12 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             decreaseNextHopRefCount(it_route->second.nhg_key);
             auto ol_nextHops = it_route->second.nhg_key;
-            if (ol_nextHops.getSize() > 1
-                && m_syncdNextHopGroups[ol_nextHops].ref_count == 0)
+            if (ol_nextHops.getSize() > 1)
             {
-                m_bulkNhgReducedRefCnt.emplace(ol_nextHops, 0);
+                if (m_syncdNextHopGroups[ol_nextHops].ref_count == 0)
+                {
+                    m_bulkNhgReducedRefCnt.emplace(ol_nextHops, 0);
+                }
             }
             else if (ol_nextHops.is_overlay_nexthop())
             {
@@ -2475,23 +2477,25 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
 
         auto ol_nextHops = it_route->second.nhg_key;
         MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
-        if (it_route->second.nhg_key.getSize() > 1
-            && m_syncdNextHopGroups[it_route->second.nhg_key].ref_count == 0)
+        if (it_route->second.nhg_key.getSize() > 1)
         {
-            m_bulkNhgReducedRefCnt.emplace(it_route->second.nhg_key, 0);
-            if (mux_orch->isMuxNexthops(ol_nextHops))
+            if (m_syncdNextHopGroups[it_route->second.nhg_key].ref_count == 0)
             {
-                SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
-                RouteKey routekey = { vrf_id, ipPrefix };
-                auto nexthop_list = ol_nextHops.getNextHops();
-                for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
+                m_bulkNhgReducedRefCnt.emplace(it_route->second.nhg_key, 0);
+                if (mux_orch->isMuxNexthops(ol_nextHops))
                 {
-                    if (!nh->ip_address.isZero())
+                    SWSS_LOG_NOTICE("Remove mux Nexthop %s", ol_nextHops.to_string().c_str());
+                    RouteKey routekey = { vrf_id, ipPrefix };
+                    auto nexthop_list = ol_nextHops.getNextHops();
+                    for (auto nh = nexthop_list.begin(); nh != nexthop_list.end(); nh++)
                     {
-                        removeNextHopRoute(*nh, routekey);
+                        if (!nh->ip_address.isZero())
+                        {
+                            removeNextHopRoute(*nh, routekey);
+                        }
                     }
+                    mux_orch->updateRoute(ipPrefix, false);
                 }
-                mux_orch->updateRoute(ipPrefix, false);
             }
         }
         else if (ol_nextHops.is_overlay_nexthop())

--- a/tests/evpn_tunnel.py
+++ b/tests/evpn_tunnel.py
@@ -1156,7 +1156,7 @@ class VxlanTunnel(object):
             assert found_route
 
         self.helper.check_deleted_object(asic_db, self.ASIC_ROUTE_ENTRY, self.route_id[vrf_name + ":" + prefix])
-        self.route_id.clear()
+        del self.route_id[vrf_name + ":" + prefix]
 
         return True
 

--- a/tests/test_evpn_l3_vxlan.py
+++ b/tests/test_evpn_l3_vxlan.py
@@ -309,6 +309,44 @@ class TestL3Vxlan(object):
         vxlan_obj.check_vrf_routes_ecmp_nexthop_grp_del(dvs, 2)
         vxlan_obj.check_del_vrf_routes(dvs, "80.80.1.0/24", 'Vrf-RED')
 
+        print ("\n\nTest VRF IPv4 Multiple Route with ECMP Tunnel Nexthop Add and Delete")
+        vxlan_obj.fetch_exist_entries(dvs)
+
+        ecmp_nexthop_attr = [
+            ("nexthop", "7.7.7.7,8.8.8.8"),
+            ("ifname", "Vlan100,Vlan100"),
+            ("vni_label", "1000,1000"),
+            ("router_mac", "00:11:11:11:11:11,00:22:22:22:22:22"),
+        ]
+
+        print ("\tTest VRF IPv4 Multiple Route with ECMP Tunnel Nexthop [7.7.7.7 , 8.8.8.8] Add")
+        vxlan_obj.create_vrf_route_ecmp(dvs, "80.80.1.0/24", 'Vrf-RED', ecmp_nexthop_attr)
+
+        nh_count = 2
+        ecmp_nhid_list = vxlan_obj.check_vrf_routes_ecmp(dvs, "80.80.1.0/24", 'Vrf-RED', tunnel_name, nh_count)
+        assert nh_count == len(ecmp_nhid_list)
+        vxlan_obj.check_add_tunnel_nexthop(dvs, ecmp_nhid_list[0], '7.7.7.7', tunnel_name, '00:11:11:11:11:11', '1000')
+        vxlan_obj.check_add_tunnel_nexthop(dvs, ecmp_nhid_list[1], '8.8.8.8', tunnel_name, '00:22:22:22:22:22', '1000')
+
+        nh_count = 2
+        vxlan_obj.create_vrf_route_ecmp(dvs, "90.90.1.0/24", 'Vrf-RED', ecmp_nexthop_attr)
+        ecmp_nhid_list = vxlan_obj.check_vrf_routes_ecmp(dvs, "90.90.1.0/24", 'Vrf-RED', tunnel_name, nh_count)
+        assert nh_count == len(ecmp_nhid_list)
+        vxlan_obj.check_add_tunnel_nexthop(dvs, ecmp_nhid_list[0], '7.7.7.7', tunnel_name, '00:11:11:11:11:11', '1000')
+        vxlan_obj.check_add_tunnel_nexthop(dvs, ecmp_nhid_list[1], '8.8.8.8', tunnel_name, '00:22:22:22:22:22', '1000')
+
+        print ("\tTest VRF IPv4 Multiple Route with ECMP Tunnel Nexthop [7.7.7.7 , 8.8.8.8] Delete")
+        vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.delete_vrf_route(dvs, "80.80.1.0/24", 'Vrf-RED')
+        vxlan_obj.check_del_vrf_routes(dvs, "80.80.1.0/24", 'Vrf-RED')
+        vxlan_obj.fetch_exist_entries(dvs)
+        vxlan_obj.delete_vrf_route(dvs, "90.90.1.0/24", 'Vrf-RED')
+        vxlan_obj.check_del_vrf_routes(dvs, "90.90.1.0/24", 'Vrf-RED')
+        helper.check_deleted_object(self.adb, vxlan_obj.ASIC_NEXT_HOP, ecmp_nhid_list[0])
+        helper.check_deleted_object(self.adb, vxlan_obj.ASIC_NEXT_HOP, ecmp_nhid_list[1])
+
+        vxlan_obj.check_vrf_routes_ecmp_nexthop_grp_del(dvs, 2)
+
         print ("\n\nTest VRF IPv4 Route with Tunnel Nexthop update from non-ECMP to ECMP")
         print ("\tTest VRF IPv4 Route with Tunnel Nexthop 7.7.7.7 Add")
         vxlan_obj.fetch_exist_entries(dvs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When multiple routes point to a nexthop group which means the ref count of ngh is more than one, there is an error condition in the removal flow. The original logic is to remove nhg only when ref count becomes zero. However due to the structuring of if else statements, if the nhg count is not zero, the logic fallbacks to removeOverlayNextHops which will also get added to the list of tasks.
Later when bulker logic kicks in, the nexthop group removal will remove the nexthops associated. However the removeOverlayNextHops  will also subsequently try to remove the same nexthops resulting in errors below.


```
Apr 19 11:51:05.323909 anc-ali-t9 NOTICE swss#orchagent: :- removeRoutePost: Remove overlay Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc,173.108.108.2@vniVlan30@30@c2:72:8d:aa:61:d2
Apr 19 11:51:05.323976 anc-ali-t9 NOTICE swss#orchagent: :- removeRoutePost: Remove overlay Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc
Apr 19 11:51:05.328042 anc-ali-t9 NOTICE swss#orchagent: :- removeOverlayNextHops: Remove overlay Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc
Apr 19 11:51:05.328081 anc-ali-t9 NOTICE swss#orchagent: :- removeNextHopGroup: Delete next hop group 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc,173.108.108.2@vniVlan30@30@c2:72:8d:aa:61:d2
Apr 19 11:51:05.329642 anc-ali-t9 NOTICE syncd#SDK: [SAI_NEXT_HOP_GROUP.NOTICE] mlnx_sai_nexthopgroup.c[951]- mlnx_remove_next_hop_group: Remove next hop group next hop group id 0x000000C8
Apr 19 11:51:05.330400 anc-ali-t9 NOTICE swss#orchagent: :- removeNextHopTunnel: NH tunnel remove for vtep1, ip 173.106.106.2, mac b6:a1:0b:0b:d3:cc, vni 30
Apr 19 11:51:05.330658 anc-ali-t9 NOTICE syncd#SDK: [SAI_NEXT_HOP.NOTICE] mlnx_sai_nexthop.c[1431]- mlnx_remove_next_hop: Remove next hop next hop id 326, ext 1
Apr 19 11:51:05.331108 anc-ali-t9 NOTICE swss#orchagent: :- removeTunnelNextHop: Removed Tunnel next hop vtep1, 173.106.106.2@30@b6:a1:0b:0b:d3:cc
Apr 19 11:51:05.331877 anc-ali-t9 NOTICE swss#orchagent: :- removeOverlayNextHops: Remove overlay Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc,173.108.108.2@vniVlan30@30@c2:72:8d:aa:61:d2
Apr 19 11:51:05.331877 anc-ali-t9 NOTICE swss#orchagent: :- removeOverlayNextHops: Remove overlay Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc,173.108.108.2@vniVlan30@30@c2:72:8d:aa:61:d2
Apr 19 11:51:05.331877 anc-ali-t9 NOTICE swss#orchagent: :- removeNextHopTunnel: NH tunnel remove for vtep1, ip 173.106.106.2, mac b6:a1:0b:0b:d3:cc, vni 30
Apr 19 11:51:05.331877 anc-ali-t9 ERR swss#orchagent: :- removeTunnelNextHop: Failed to remove Tunnel next hop vtep1, 173.106.106.2@30@b6:a1:0b:0b:d3:cc
Apr 19 11:51:05.331877 anc-ali-t9 ERR swss#orchagent: :- removeOverlayNextHops: Tunnel Nexthop 173.106.106.2@vniVlan30@30@b6:a1:0b:0b:d3:cc,173.108.108.2@vniVlan30@30@c2:72:8d:aa:61:d2 delete failed
```

**Why I did it**
To fix proper handling of ECMP pointed by multiple routes.

**How I verified it**
Added VS tests to verify.

**Details if related**
