### PR TITLE
[ASAN]Increasing switch create timeout for ASAN images

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -585,15 +585,13 @@ int main(int argc, char **argv)
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
-    bool asan_enabled = false;
-    uint32_t delay_factor = 1;
+    auto delay_factor = 1;
 
 #ifdef ASAN_ENABLED
-    asan_enabled = true;
     delay_factor = 2;
+#else
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
 #endif
-
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet" || asan_enabled)
     {
         /* We set this long timeout in order for orchagent to wait enough time for
          * response from syncd. It is needed since switch create takes more time

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -600,6 +600,7 @@ int main(int argc, char **argv)
          * than default time to create switch if there are lots of front panel ports
          * and systems ports to initialize
          */
+
         if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet")
         {
             attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -579,13 +579,21 @@ int main(int argc, char **argv)
         attr.value.u32 = SAI_SWITCH_TYPE_FABRIC;
         attrs.push_back(attr);
     }
-
     /* Must be last Attribute */
     attr.id = SAI_REDIS_SWITCH_ATTR_CONTEXT;
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
-    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet")
+    bool asan_enabled = false;
+    uint32_t asan_delay_factor = 1;
+    uint32_t redis_timeout = SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT;
+
+#ifdef ASAN_ENABLED
+    asan_enabled = true;
+    asan_delay_factor = 2;
+#endif
+
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet" || asan_enabled)
     {
         /* We set this long timeout in order for orchagent to wait enough time for
          * response from syncd. It is needed since switch create takes more time
@@ -595,13 +603,14 @@ int main(int argc, char **argv)
 
         if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet")
         {
-            attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+            redis_timeout = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
         else if (gMySwitchType == "fabric")
         {
-            attr.value.u64 = (10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+            redis_timeout = (10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
 
+        attr.value.u64 = redis_timeout*asan_delay_factor;
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
         status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -579,18 +579,18 @@ int main(int argc, char **argv)
         attr.value.u32 = SAI_SWITCH_TYPE_FABRIC;
         attrs.push_back(attr);
     }
+
     /* Must be last Attribute */
     attr.id = SAI_REDIS_SWITCH_ATTR_CONTEXT;
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
     bool asan_enabled = false;
-    uint32_t asan_delay_factor = 1;
-    uint32_t redis_timeout = SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT;
+    uint32_t delay_factor = 1;
 
 #ifdef ASAN_ENABLED
     asan_enabled = true;
-    asan_delay_factor = 2;
+    delay_factor = 2;
 #endif
 
     if (gMySwitchType == "voq" || gMySwitchType == "fabric" || gMySwitchType == "chassis-packet" || asan_enabled)
@@ -600,17 +600,20 @@ int main(int argc, char **argv)
          * than default time to create switch if there are lots of front panel ports
          * and systems ports to initialize
          */
-
         if (gMySwitchType == "voq" || gMySwitchType == "chassis-packet")
         {
-            redis_timeout = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+            attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
         else if (gMySwitchType == "fabric")
         {
-            redis_timeout = (10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+            attr.value.u64 = (10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
+        }
+        else
+        {
+            attr.value.u64 = SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT;
         }
 
-        attr.value.u64 = redis_timeout*asan_delay_factor;
+        attr.value.u64 = attr.value.u64*delay_factor;
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
         status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When running ASAN images with low CPU systems, due to the additional overhead associated with ASAN, it results in switch create timeout as seen in logs below. Hence increasing the switch create timeout for ASAN builds.

```
Apr 18 20:23:46.749074 arc-switch1004 NOTICE swss#orchagent: :- create: request switch create with context 0
Apr 18 20:23:46.749074 arc-switch1004 NOTICE swss#orchagent: :- allocateNewSwitchObjectId: created SWITCH VID oid:0x21000000000000 for hwinfo: ''
Apr 18 20:24:46.816998 arc-switch1004 ERR swss#orchagent: :- wait: SELECT operation result: TIMEOUT on getresponse
Apr 18 20:24:46.817243 arc-switch1004 ERR swss#orchagent: :- wait: failed to get response for getresponse
Apr 18 20:24:46.817405 arc-switch1004 ERR swss#orchagent: :- create: create status: SAI_STATUS_FAILURE
Apr 18 20:24:46.817552 arc-switch1004 ERR swss#orchagent: :- main: Failed to create a switch, rv:-1

```

**Why I did it**
To avoid timeout to create switch when testing ASAN builds with lower CPU systems

**How I verified it**
Loaded the build with changes and verified no issues are seen

**Details if related**
