### PR TITLE
[FEC] Adding support of FEC override through attribute query

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -322,6 +322,7 @@ private:
     map<string, uint32_t> m_bridge_port_ref_count;
 
     NotificationConsumer* m_portStatusNotificationConsumer;
+    bool fec_override_sup = false;
 
     swss::SelectableTimer *m_port_state_poller = nullptr;
 

--- a/tests/test_port_fec_override.py
+++ b/tests/test_port_fec_override.py
@@ -1,0 +1,30 @@
+import time
+import os
+import pytest
+
+from swsscommon import swsscommon
+
+DVS_ENV = ["HWSKU=Mellanox-SN2700"]
+
+class TestPort(object):
+    def test_PortFecOverride(self, dvs, testlog):
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = dvs.get_asic_db()
+
+        ptbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+
+        # set fec
+        fvs = swsscommon.FieldValuePairs([("fec","rs")])
+        ptbl.set("Ethernet4", fvs)
+
+        # validate if fec rs is pushed to asic db when set first time
+        port_oid = adb.port_name_map["Ethernet4"]
+        expected_fields = {"SAI_PORT_ATTR_FEC_MODE":"SAI_PORT_FEC_MODE_RS", "SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE":"true"}
+        adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass
+


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Providing support of FEC override functionality existing today through attribute query of SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE

**Why I did it**
Today when FEC is enabled by user in SONiC it should explicitly override any auto negotiated values. However when the support SAI_PORT_ATTR_AUTO_NEG_FEC_MODE_OVERRIDE exists in vendor SAI, it should be queried and used to get this functionality.

**How I verified it**
Adding UT to verify it.

**Details if related**
