### PR TITLE
Fix oper FEC retrieval after warm-boot

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -549,24 +549,23 @@ void BufferMgr::doTask(Consumer &consumer)
                     task_status = doSpeedUpdateTask(port);
                 }
             }
-
-            switch (task_status)
-            {
-                case task_process_status::task_failed:
-                    SWSS_LOG_ERROR("Failed to process table update");
-                    return;
-                case task_process_status::task_need_retry:
-                    SWSS_LOG_INFO("Unable to process table update. Will retry...");
-                    ++it;
-                    break;
-                case task_process_status::task_invalid_entry:
-                    SWSS_LOG_ERROR("Failed to process invalid entry, drop it");
-                    it = consumer.m_toSync.erase(it);
-                    break;
-                default:
-                    it = consumer.m_toSync.erase(it);
-                    break;
-            }
+        }
+        switch (task_status)
+        {
+            case task_process_status::task_failed:
+                SWSS_LOG_ERROR("Failed to process table update");
+                return;
+            case task_process_status::task_need_retry:
+                SWSS_LOG_INFO("Unable to process table update. Will retry...");
+                ++it;
+                break;
+            case task_process_status::task_invalid_entry:
+                SWSS_LOG_ERROR("Failed to process invalid entry, drop it");
+                it = consumer.m_toSync.erase(it);
+                break;
+            default:
+                it = consumer.m_toSync.erase(it);
+                break;
         }
     }
 }

--- a/cfgmgr/coppmgr.cpp
+++ b/cfgmgr/coppmgr.cpp
@@ -21,10 +21,11 @@ static set<string> g_copp_init_set;
 
 void CoppMgr::parseInitFile(void)
 {
-    std::ifstream ifs(COPP_INIT_FILE);
+    std::ifstream ifs(m_coppCfgfile);
+
     if (ifs.fail())
     {
-        SWSS_LOG_ERROR("COPP init file %s not found", COPP_INIT_FILE);
+        SWSS_LOG_ERROR("COPP init file %s not found", m_coppCfgfile.c_str());
         return;
     }
     json j = json::parse(ifs);
@@ -293,7 +294,7 @@ bool CoppMgr::isDupEntry(const std::string &key, std::vector<FieldValueTuple> &f
     return true;
 }
 
-CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
+CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames, const string copp_init_file) :
         Orch(cfgDb, tableNames),
         m_cfgCoppTrapTable(cfgDb, CFG_COPP_TRAP_TABLE_NAME),
         m_cfgCoppGroupTable(cfgDb, CFG_COPP_GROUP_TABLE_NAME),
@@ -301,7 +302,8 @@ CoppMgr::CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_appCoppTable(appDb, APP_COPP_TABLE_NAME),
         m_stateCoppTrapTable(stateDb, STATE_COPP_TRAP_TABLE_NAME),
         m_stateCoppGroupTable(stateDb, STATE_COPP_GROUP_TABLE_NAME),
-        m_coppTable(appDb, APP_COPP_TABLE_NAME)
+        m_coppTable(appDb, APP_COPP_TABLE_NAME),
+        m_coppCfgfile(copp_init_file)
 {
     SWSS_LOG_ENTER();
     parseInitFile();

--- a/cfgmgr/coppmgr.h
+++ b/cfgmgr/coppmgr.h
@@ -62,7 +62,7 @@ class CoppMgr : public Orch
 {
 public:
     CoppMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb,
-        const std::vector<std::string> &tableNames);
+        const std::vector<std::string> &tableNames, const std::string copp_init_file = COPP_INIT_FILE);
 
     using Orch::doTask;
 private:
@@ -75,6 +75,7 @@ private:
     CoppCfg                m_coppGroupInitCfg;
     CoppCfg                m_coppTrapInitCfg;
     CoppCfg                m_featuresCfgTable;
+    std::string            m_coppCfgfile;
 
 
     void doTask(Consumer &consumer);

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -113,7 +113,8 @@ orchagent_SOURCES = \
             dash/dashaclorch.cpp \
             dash/dashaclgroupmgr.cpp \
             dash/dashtagmgr.cpp \
-            dash/pbutils.cpp
+            dash/pbutils.cpp \
+            twamporch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp flex_counter/flowcounterrouteorch.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3223,7 +3223,6 @@ void AclOrch::initDefaultTableTypes()
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS))
-            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()
     );
 
@@ -3241,7 +3240,6 @@ void AclOrch::initDefaultTableTypes()
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT))
             .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS))
-            .withMatch(make_shared<AclTableMatch>(SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS))
             .build()
     );
 

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -64,6 +64,7 @@ const map<CrmResourceType, string> crmResTypeNameMap =
     { CrmResourceType::CRM_DASH_IPV6_ACL_GROUP, "DASH_IPV6_ACL_GROUP" },
     { CrmResourceType::CRM_DASH_IPV4_ACL_RULE, "DASH_IPV4_ACL_RULE" },
     { CrmResourceType::CRM_DASH_IPV6_ACL_RULE, "DASH_IPV6_ACL_RULE" },
+    { CrmResourceType::CRM_TWAMP_ENTRY, "TWAMP_ENTRY" }
 };
 
 const map<CrmResourceType, uint32_t> crmResSaiAvailAttrMap =
@@ -84,6 +85,7 @@ const map<CrmResourceType, uint32_t> crmResSaiAvailAttrMap =
     { CrmResourceType::CRM_IPMC_ENTRY, SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY},
     { CrmResourceType::CRM_SNAT_ENTRY, SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY },
     { CrmResourceType::CRM_DNAT_ENTRY, SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY },
+    { CrmResourceType::CRM_TWAMP_ENTRY, SAI_SWITCH_ATTR_AVAILABLE_TWAMP_SESSION }
 };
 
 const map<CrmResourceType, sai_object_type_t> crmResSaiObjAttrMap =
@@ -125,6 +127,7 @@ const map<CrmResourceType, sai_object_type_t> crmResSaiObjAttrMap =
     { CrmResourceType::CRM_DASH_IPV6_ACL_GROUP, (sai_object_type_t)SAI_OBJECT_TYPE_DASH_ACL_GROUP },
     { CrmResourceType::CRM_DASH_IPV4_ACL_RULE, (sai_object_type_t)SAI_OBJECT_TYPE_DASH_ACL_RULE },
     { CrmResourceType::CRM_DASH_IPV6_ACL_RULE, (sai_object_type_t)SAI_OBJECT_TYPE_DASH_ACL_RULE },
+    { CrmResourceType::CRM_TWAMP_ENTRY, SAI_OBJECT_TYPE_NULL }
 };
 
 const map<CrmResourceType, sai_attr_id_t> crmResAddrFamilyAttrMap =
@@ -185,7 +188,8 @@ const map<string, CrmResourceType> crmThreshTypeResMap =
     { "dash_ipv4_acl_group_threshold_type", CrmResourceType::CRM_DASH_IPV4_ACL_GROUP },
     { "dash_ipv6_acl_group_threshold_type", CrmResourceType::CRM_DASH_IPV6_ACL_GROUP },
     { "dash_ipv4_acl_rule_threshold_type", CrmResourceType::CRM_DASH_IPV4_ACL_RULE },
-    { "dash_ipv6_acl_rule_threshold_type", CrmResourceType::CRM_DASH_IPV6_ACL_RULE }
+    { "dash_ipv6_acl_rule_threshold_type", CrmResourceType::CRM_DASH_IPV6_ACL_RULE },
+    { "twamp_entry_threshold_type", CrmResourceType::CRM_TWAMP_ENTRY }
 };
 
 const map<string, CrmResourceType> crmThreshLowResMap =
@@ -226,7 +230,8 @@ const map<string, CrmResourceType> crmThreshLowResMap =
     { "dash_ipv4_acl_group_low_threshold", CrmResourceType::CRM_DASH_IPV4_ACL_GROUP },
     { "dash_ipv6_acl_group_low_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_GROUP },
     { "dash_ipv4_acl_rule_low_threshold", CrmResourceType::CRM_DASH_IPV4_ACL_RULE },
-    { "dash_ipv6_acl_rule_low_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_RULE }
+    { "dash_ipv6_acl_rule_low_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_RULE },
+    { "twamp_entry_low_threshold", CrmResourceType::CRM_TWAMP_ENTRY }
 };
 
 const map<string, CrmResourceType> crmThreshHighResMap =
@@ -267,7 +272,8 @@ const map<string, CrmResourceType> crmThreshHighResMap =
     { "dash_ipv4_acl_group_high_threshold", CrmResourceType::CRM_DASH_IPV4_ACL_GROUP },
     { "dash_ipv6_acl_group_high_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_GROUP },
     { "dash_ipv4_acl_rule_high_threshold", CrmResourceType::CRM_DASH_IPV4_ACL_RULE },
-    { "dash_ipv6_acl_rule_high_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_RULE }
+    { "dash_ipv6_acl_rule_high_threshold", CrmResourceType::CRM_DASH_IPV6_ACL_RULE },
+    { "twamp_entry_high_threshold", CrmResourceType::CRM_TWAMP_ENTRY }
 };
 
 const map<string, CrmThresholdType> crmThreshTypeMap =
@@ -315,7 +321,8 @@ const map<string, CrmResourceType> crmAvailCntsTableMap =
     { "crm_stats_dash_ipv4_acl_group_available", CrmResourceType::CRM_DASH_IPV4_ACL_GROUP },
     { "crm_stats_dash_ipv6_acl_group_available", CrmResourceType::CRM_DASH_IPV6_ACL_GROUP },
     { "crm_stats_dash_ipv4_acl_rule_available", CrmResourceType::CRM_DASH_IPV4_ACL_RULE },
-    { "crm_stats_dash_ipv6_acl_rule_available", CrmResourceType::CRM_DASH_IPV6_ACL_RULE }
+    { "crm_stats_dash_ipv6_acl_rule_available", CrmResourceType::CRM_DASH_IPV6_ACL_RULE },
+    { "crm_stats_twamp_entry_available", CrmResourceType::CRM_TWAMP_ENTRY }
 };
 
 const map<string, CrmResourceType> crmUsedCntsTableMap =
@@ -356,7 +363,8 @@ const map<string, CrmResourceType> crmUsedCntsTableMap =
     { "crm_stats_dash_ipv4_acl_group_used", CrmResourceType::CRM_DASH_IPV4_ACL_GROUP },
     { "crm_stats_dash_ipv6_acl_group_used", CrmResourceType::CRM_DASH_IPV6_ACL_GROUP },
     { "crm_stats_dash_ipv4_acl_rule_used", CrmResourceType::CRM_DASH_IPV4_ACL_RULE },
-    { "crm_stats_dash_ipv6_acl_rule_used", CrmResourceType::CRM_DASH_IPV6_ACL_RULE }
+    { "crm_stats_dash_ipv6_acl_rule_used", CrmResourceType::CRM_DASH_IPV6_ACL_RULE },
+    { "crm_stats_twamp_entry_used", CrmResourceType::CRM_TWAMP_ENTRY },
 };
 
 CrmOrch::CrmOrch(DBConnector *db, string tableName):
@@ -877,6 +885,7 @@ void CrmOrch::getResAvailableCounters()
             case CrmResourceType::CRM_DASH_IPV6_OUTBOUND_CA_TO_PA:
             case CrmResourceType::CRM_DASH_IPV4_ACL_GROUP:
             case CrmResourceType::CRM_DASH_IPV6_ACL_GROUP:
+            case CrmResourceType::CRM_TWAMP_ENTRY:
             {
                 getResAvailability(res.first, res.second);
                 break;

--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -49,7 +49,8 @@ enum class CrmResourceType
     CRM_DASH_IPV4_ACL_GROUP,
     CRM_DASH_IPV6_ACL_GROUP,
     CRM_DASH_IPV4_ACL_RULE,
-    CRM_DASH_IPV6_ACL_RULE
+    CRM_DASH_IPV6_ACL_RULE,
+    CRM_TWAMP_ENTRY
 };
 
 enum class CrmThresholdType

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1385,7 +1385,7 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                 continue;
             }
 
-            MacAddress mac_address;
+            MacAddress mac_address, original_mac_address;
             uint32_t encap_index = 0;
             for (auto i = kfvFieldsValues(t).begin();
                  i  != kfvFieldsValues(t).end(); i++)
@@ -1465,42 +1465,13 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     //kernel programming.
                     if(ibif.m_type != Port::VLAN)
                     {
+                        original_mac_address = mac_address;
                         mac_address = gMacAddress;
-
-                        // For VS platforms, the mac of the static neigh should not be same as asic's own mac.
-                        // This is because host originated packets will have same mac for both src and dst which
-                        // will result in host NOT sending packet out. To address this problem which is specific
-                        // to port type inband interfaces, set the mac to the neighbor's owner asic's mac. Since
-                        // the owner asic's mac is not readily avaiable here, the owner asic mac is derived from
-                        // the switch id and lower 5 bytes of asic mac which is assumed to be same for all asics
-                        // in the VS system.
-                        // Therefore to make VOQ chassis systems work in VS platform based setups like the setups
-                        // using KVMs, it is required that all asics have same base mac in the format given below
-                        // <lower 5 bytes of mac same for all asics>:<6th byte = switch_id>
-
                         string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
-
+                        // For VS platform, use the original MAC address
                         if (platform == VS_PLATFORM_SUBSTRING)
                         {
-                            int8_t sw_id = -1;
-                            uint8_t egress_asic_mac[ETHER_ADDR_LEN];
-
-                            gMacAddress.getMac(egress_asic_mac);
-
-                            if (p.m_type == Port::LAG)
-                            {
-                                sw_id = (int8_t) p.m_system_lag_info.switch_id;
-                            }
-                            else if (p.m_type == Port::PHY || p.m_type == Port::SYSTEM)
-                            {
-                                sw_id = (int8_t) p.m_system_port_info.switch_id;
-                            }
-
-                            if(sw_id != -1)
-                            {
-                                egress_asic_mac[5] = sw_id;
-                                mac_address = MacAddress(egress_asic_mac);
-                            }
+                            mac_address = original_mac_address;
                         }
                     }
                     vector<FieldValueTuple> fvVector;

--- a/orchagent/notifications.cpp
+++ b/orchagent/notifications.cpp
@@ -27,6 +27,12 @@ void on_bfd_session_state_change(uint32_t count, sai_bfd_session_state_notificat
     // which causes concurrency access to the DB
 }
 
+void on_twamp_session_event(uint32_t count, sai_twamp_session_event_notification_data_t *data)
+{
+    // don't use this event handler, because it runs by libsairedis in a separate thread
+    // which causes concurrency access to the DB
+}
+
 void on_switch_shutdown_request(sai_object_id_t switch_id)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/notifications.h
+++ b/orchagent/notifications.h
@@ -7,6 +7,7 @@ extern "C" {
 void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data);
 void on_port_state_change(uint32_t count, sai_port_oper_status_notification_t *data);
 void on_bfd_session_state_change(uint32_t count, sai_bfd_session_state_notification_t *data);
+void on_twamp_session_event(uint32_t count, sai_twamp_session_event_notification_data_t *data);
 
 // The function prototype information can be found here:
 //      https://github.com/sonic-net/sonic-sairedis/blob/master/meta/NotificationSwitchShutdownRequest.cpp#L49

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -727,6 +727,11 @@ bool OrchDaemon::init()
     gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
     m_orchList.push_back(gP4Orch);
 
+    TableConnector confDbTwampTable(m_configDb, CFG_TWAMP_SESSION_TABLE_NAME);
+    TableConnector stateDbTwampTable(m_stateDb, STATE_TWAMP_SESSION_TABLE_NAME);
+    TwampOrch *twamp_orch = new TwampOrch(confDbTwampTable, stateDbTwampTable, gSwitchOrch, gPortsOrch, vrf_orch);
+    m_orchList.push_back(twamp_orch);
+
     if (WarmStart::isWarmStart())
     {
         bool suc = warmRestoreAndSyncUp();

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -46,6 +46,7 @@
 #include "bfdorch.h"
 #include "srv6orch.h"
 #include "nvgreorch.h"
+#include "twamporch.h"
 #include "dash/dashaclorch.h"
 #include "dash/dashorch.h"
 #include "dash/dashrouteorch.h"

--- a/orchagent/p4orch/acl_rule_manager.cpp
+++ b/orchagent/p4orch/acl_rule_manager.cpp
@@ -9,7 +9,6 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "intfsorch.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"
@@ -18,6 +17,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -165,7 +165,8 @@ std::vector<sai_attribute_t> getMeterSaiAttrs(const P4AclMeter &p4_acl_meter)
 
 } // namespace
 
-ReturnCode AclRuleManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode AclRuleManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/acl_rule_manager.h
+++ b/orchagent/p4orch/acl_rule_manager.h
@@ -44,7 +44,8 @@ class AclRuleManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Update counters stats for every rule in each ACL table in COUNTERS_DB, if
     // counters are enabled in rules.

--- a/orchagent/p4orch/acl_table_manager.cpp
+++ b/orchagent/p4orch/acl_table_manager.cpp
@@ -7,7 +7,6 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch.h"
@@ -16,6 +15,7 @@
 #include "switchorch.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -205,7 +205,8 @@ ReturnCodeOr<std::vector<sai_attribute_t>> AclTableManager::getUdfSaiAttrs(const
     return udf_attrs;
 }
 
-ReturnCode AclTableManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode AclTableManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                         std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/acl_table_manager.h
+++ b/orchagent/p4orch/acl_table_manager.h
@@ -34,7 +34,8 @@ class AclTableManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Get ACL table definition by table name in cache. Return nullptr if not
     // found.

--- a/orchagent/p4orch/acl_util.cpp
+++ b/orchagent/p4orch/acl_util.cpp
@@ -1,11 +1,11 @@
 #include "p4orch/acl_util.h"
 
 #include "converter.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 
 namespace p4orch
 {

--- a/orchagent/p4orch/acl_util.h
+++ b/orchagent/p4orch/acl_util.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/ext_tables_manager.cpp
+++ b/orchagent/p4orch/ext_tables_manager.cpp
@@ -1,22 +1,22 @@
 #include "p4orch/ext_tables_manager.h"
 
+#include <boost/algorithm/string.hpp>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
-#include "directory.h"
-#include <nlohmann/json.hpp>
-#include "logger.h"
-#include "tokenize.h"
-#include "orch.h"
 #include "crmorch.h"
+#include "directory.h"
+#include "logger.h"
+#include "orch.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "tokenize.h"
+#include <nlohmann/json.hpp>
 
-extern sai_counter_api_t*   sai_counter_api;
+extern sai_counter_api_t *sai_counter_api;
 extern sai_generic_programmable_api_t *sai_generic_programmable_api;
 
 extern Directory<Orch *> gDirectory;
@@ -43,10 +43,10 @@ std::string getCrossRefTableName(const std::string table_name)
     auto it = FixedTablesMap.find(table_name);
     if (it != FixedTablesMap.end())
     {
-        return(it->second);
+        return (it->second);
     }
 
-    return(table_name);
+    return (table_name);
 }
 
 ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &app_db_entry, ActionInfo *action)
@@ -55,8 +55,7 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
     std::unordered_map<std::string, nlohmann::json> cross_ref_key_j;
     ReturnCode status;
 
-    for (auto param_defn_it = action->params.begin();
-              param_defn_it != action->params.end(); param_defn_it++)
+    for (auto param_defn_it = action->params.begin(); param_defn_it != action->params.end(); param_defn_it++)
     {
         ActionParamInfo action_param_defn = param_defn_it->second;
         if (action_param_defn.table_reference_map.empty())
@@ -71,16 +70,16 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         {
             SWSS_LOG_ERROR("Required param not specified for action %s\n", action_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Required param not specified for action %s " << action_name.c_str();
+                   << "Required param not specified for action %s " << action_name.c_str();
         }
 
         for (auto cross_ref_it = action_param_defn.table_reference_map.begin();
-                  cross_ref_it != action_param_defn.table_reference_map.end(); cross_ref_it++)
+             cross_ref_it != action_param_defn.table_reference_map.end(); cross_ref_it++)
         {
-            cross_ref_key_j[cross_ref_it->first].push_back(nlohmann::json::object_t::value_type(prependMatchField(cross_ref_it->second), app_db_param_it->second));
+            cross_ref_key_j[cross_ref_it->first].push_back(
+                nlohmann::json::object_t::value_type(prependMatchField(cross_ref_it->second), app_db_param_it->second));
         }
     }
-
 
     for (auto it = cross_ref_key_j.begin(); it != cross_ref_key_j.end(); it++)
     {
@@ -88,7 +87,7 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         const std::string table_key = it->second.dump();
         std::string key;
         sai_object_type_t object_type;
-        sai_object_id_t   oid;
+        sai_object_id_t oid;
         DepObject dep_object = {};
 
         if (gP4Orch->m_p4TableToManagerMap.find(table_name) != gP4Orch->m_p4TableToManagerMap.end())
@@ -98,10 +97,10 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
             {
                 SWSS_LOG_ERROR("Cross-table reference validation failed from fixed-table %s", table_name.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                   << "Cross-table reference valdiation failed from fixed-table";
+                       << "Cross-table reference valdiation failed from fixed-table";
             }
         }
-       	else 
+        else
         {
             if (getTableInfo(table_name))
             {
@@ -109,16 +108,18 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
                 status = getSaiObject(ext_table_key, object_type, key);
                 if (!status.ok())
                 {
-                    SWSS_LOG_ERROR("Cross-table reference validation failed from extension-table %s", table_name.c_str());
+                    SWSS_LOG_ERROR("Cross-table reference validation failed from extension-table %s",
+                                   table_name.c_str());
                     return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                       << "Cross-table reference valdiation failed from extension table";
+                           << "Cross-table reference valdiation failed from extension table";
                 }
             }
             else
             {
-                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table %s", table_name.c_str());
+                SWSS_LOG_ERROR("Cross-table reference validation failed due to non-existent table %s",
+                               table_name.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                       << "Cross-table reference valdiation failed due to non-existent table";
+                       << "Cross-table reference valdiation failed due to non-existent table";
             }
         }
 
@@ -126,19 +127,19 @@ ReturnCode ExtTablesManager::validateActionParamsCrossRef(P4ExtTableAppDbEntry &
         {
             SWSS_LOG_ERROR("Cross-table reference validation failed, no OID found from table %s", table_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                               << "Cross-table reference valdiation failed, no OID found";
+                   << "Cross-table reference valdiation failed, no OID found";
         }
 
         if (oid == SAI_NULL_OBJECT_ID)
         {
-            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from table %s", table_name.c_str());
-            return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                               << "Cross-table reference valdiation failed, null OID";
+            SWSS_LOG_ERROR("Cross-table reference validation failed, null OID expected from table %s",
+                           table_name.c_str());
+            return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Cross-table reference valdiation failed, null OID";
         }
 
-        dep_object.sai_object  = object_type;
-        dep_object.key         = key;
-        dep_object.oid         = oid;
+        dep_object.sai_object = object_type;
+        dep_object.key = key;
+        dep_object.oid = oid;
         app_db_entry.action_dep_objects[action_name] = dep_object;
     }
 
@@ -157,7 +158,7 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
     {
         SWSS_LOG_ERROR("Not a valid extension table %s", app_db_entry.table_name.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Not a valid extension table " << app_db_entry.table_name.c_str();
+               << "Not a valid extension table " << app_db_entry.table_name.c_str();
     }
 
     if (table->action_ref_tables.empty())
@@ -167,15 +168,15 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
 
     ActionInfo *action;
     for (auto app_db_action_it = app_db_entry.action_params.begin();
-              app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
+         app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
     {
         auto action_name = app_db_action_it->first;
         action = getTableActionInfo(table, action_name);
         if (action == nullptr)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Not a valid action " << action_name.c_str()
-                     << " in extension table " << app_db_entry.table_name.c_str();
+                   << "Not a valid action " << action_name.c_str() << " in extension table "
+                   << app_db_entry.table_name.c_str();
         }
 
         if (!action->refers_to)
@@ -186,25 +187,23 @@ ReturnCode ExtTablesManager::validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &
         status = validateActionParamsCrossRef(app_db_entry, action);
         if (!status.ok())
         {
-           return status;
+            return status;
         }
     }
 
     return ReturnCode();
 }
 
-
 ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
-    const std::string &table_name,
-    const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
+    const std::string &table_name, const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
 {
-    std::string  action_name;
+    std::string action_name;
 
     SWSS_LOG_ENTER();
 
     P4ExtTableAppDbEntry app_db_entry_or = {};
     app_db_entry_or.table_name = table_name;
-    app_db_entry_or.table_key  = key;
+    app_db_entry_or.table_key = key;
 
     action_name = "";
     for (const auto &it : attributes)
@@ -223,7 +222,7 @@ ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
         {
             SWSS_LOG_ERROR("Unknown extension entry field");
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "Unknown extension entry field " << QuotedVar(field);
+                   << "Unknown extension entry field " << QuotedVar(field);
         }
 
         const auto &prefix = tokenized_fields[0];
@@ -244,11 +243,10 @@ ReturnCodeOr<P4ExtTableAppDbEntry> ExtTablesManager::deserializeP4ExtTableEntry(
     return app_db_entry_or;
 }
 
-
 ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry,
                                                       std::string &ext_table_entry_attr)
 {
-    nlohmann::json   sai_j, sai_metadata_j, sai_array_j = {}, sai_entry_j;
+    nlohmann::json sai_j, sai_metadata_j, sai_array_j = {}, sai_entry_j;
 
     SWSS_LOG_ENTER();
 
@@ -260,37 +258,37 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
         {
             SWSS_LOG_ERROR("extension entry for invalid table %s", app_db_entry.table_name.c_str());
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                         << "extension entry for invalid table " << app_db_entry.table_name.c_str();
+                   << "extension entry for invalid table " << app_db_entry.table_name.c_str();
         }
 
         nlohmann::json j = nlohmann::json::parse(app_db_entry.table_key);
         for (auto it = j.begin(); it != j.end(); ++it)
         {
-            std::string   match, value, prefix;
-            std::size_t   pos;
+            std::string match, value, prefix;
+            std::size_t pos;
 
             match = it.key();
             value = it.value();
 
-	    prefix = p4orch::kMatchPrefix;
+            prefix = p4orch::kMatchPrefix;
             pos = match.rfind(prefix);
             if (pos != std::string::npos)
             {
                 match.erase(0, prefix.length());
             }
-	    else
+            else
             {
                 SWSS_LOG_ERROR("Failed to encode match fields for sai call");
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Failed to encode match fields for sai call";
             }
 
-	    prefix = p4orch::kFieldDelimiter;
+            prefix = p4orch::kFieldDelimiter;
             pos = match.rfind(prefix);
             if (pos != std::string::npos)
             {
                 match.erase(0, prefix.length());
             }
-	    else
+            else
             {
                 SWSS_LOG_ERROR("Failed to encode match fields for sai call");
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "Failed to encode match fields for sai call";
@@ -301,7 +299,7 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
             {
                 SWSS_LOG_ERROR("extension entry for invalid match field %s", match.c_str());
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                         << "extension entry for invalid match field " << match.c_str();
+                       << "extension entry for invalid match field " << match.c_str();
             }
 
             sai_metadata_j = nlohmann::json::object({});
@@ -315,7 +313,7 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
         }
 
         for (auto app_db_action_it = app_db_entry.action_params.begin();
-                  app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
+             app_db_action_it != app_db_entry.action_params.end(); app_db_action_it++)
         {
             sai_j = nlohmann::json::object({});
             auto action_dep_object_it = app_db_entry.action_dep_objects.find(app_db_action_it->first);
@@ -323,9 +321,9 @@ ReturnCode ExtTablesManager::prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry
             {
                 auto action_defn_it = table->action_fields.find(app_db_action_it->first);
                 for (auto app_db_param_it = app_db_action_it->second.begin();
-                          app_db_param_it != app_db_action_it->second.end(); app_db_param_it++)
+                     app_db_param_it != app_db_action_it->second.end(); app_db_param_it++)
                 {
-                    nlohmann::json  params_j = nlohmann::json::object({});
+                    nlohmann::json params_j = nlohmann::json::object({});
                     if (action_defn_it != table->action_fields.end())
                     {
                         auto param_defn_it = action_defn_it->second.params.find(app_db_param_it->first);
@@ -396,9 +394,8 @@ bool createGenericCounter(sai_object_id_t &counter_id)
     return true;
 }
 
-
 ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry,
-                                              P4ExtTableEntry &ext_table_entry)
+                                                   P4ExtTableEntry &ext_table_entry)
 {
     ReturnCode status;
     sai_object_type_t object_type;
@@ -428,22 +425,20 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     generic_programmable_attr.value.json.json.list = (int8_t *)const_cast<char *>(ext_table_entry_attr.c_str());
     generic_programmable_attrs.push_back(generic_programmable_attr);
 
-
     auto *table = getTableInfo(app_db_entry.table_name);
     if (!table)
     {
         SWSS_LOG_ERROR("extension entry for invalid table %s", app_db_entry.table_name.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                          << "extension entry for invalid table " << app_db_entry.table_name.c_str();
+               << "extension entry for invalid table " << app_db_entry.table_name.c_str();
     }
 
     if (table->counter_bytes_enabled || table->counter_packets_enabled)
     {
         if (!createGenericCounter(counter_id))
         {
-            SWSS_LOG_WARN("Failed to create counter for table %s, key %s\n",
-       	                  app_db_entry.table_name.c_str(),
-       	                  app_db_entry.table_key.c_str());
+            SWSS_LOG_WARN("Failed to create counter for table %s, key %s\n", app_db_entry.table_name.c_str(),
+                          app_db_entry.table_key.c_str());
         }
         else
         {
@@ -457,32 +452,28 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
 
     sai_object_id_t sai_generic_programmable_oid = SAI_NULL_OBJECT_ID;
     sai_status_t sai_status = sai_generic_programmable_api->create_generic_programmable(
-                              &sai_generic_programmable_oid, gSwitchId,
-                              (uint32_t)generic_programmable_attrs.size(),
-                              generic_programmable_attrs.data());
+        &sai_generic_programmable_oid, gSwitchId, (uint32_t)generic_programmable_attrs.size(),
+        generic_programmable_attrs.data());
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("create sai api call failed for extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), app_db_entry.table_key.c_str());
+                       app_db_entry.table_name.c_str(), app_db_entry.table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "create sai api call failed for extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << app_db_entry.table_key.c_str();
+               << "create sai api call failed for extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << app_db_entry.table_key.c_str();
     }
     std::string crm_table_name = "EXT_" + app_db_entry.table_name;
     boost::algorithm::to_upper(crm_table_name);
     gCrmOrch->incCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
 
-
     ext_table_entry.sai_entry_oid = sai_generic_programmable_oid;
     for (auto action_dep_object_it = app_db_entry.action_dep_objects.begin();
-              action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->increaseRefCount(action_dep_object.sai_object, action_dep_object.key);
         ext_table_entry.action_dep_objects[action_dep_object_it->first] = action_dep_object;
     }
-
 
     auto ext_table_key = KeyGenerator::generateExtTableKey(app_db_entry.table_name, app_db_entry.table_key);
     status = getSaiObject(ext_table_key, object_type, key);
@@ -497,9 +488,8 @@ ReturnCode ExtTablesManager::createP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     return ReturnCode();
 }
 
-
 ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry,
-                                              P4ExtTableEntry *ext_table_entry)
+                                                   P4ExtTableEntry *ext_table_entry)
 {
     ReturnCode status;
     std::string ext_table_entry_attr;
@@ -510,11 +500,10 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     if (ext_table_entry->sai_entry_oid == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("update sai api call for NULL extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
+                       app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "update sai api call for NULL extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << ext_table_entry->table_key.c_str();
+               << "update sai api call for NULL extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << ext_table_entry->table_key.c_str();
     }
 
     status = prepareP4SaiExtAPIParams(app_db_entry, ext_table_entry_attr);
@@ -531,24 +520,21 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     generic_programmable_attr.value.json.json.list = (int8_t *)const_cast<char *>(ext_table_entry_attr.c_str());
 
     sai_status_t sai_status = sai_generic_programmable_api->set_generic_programmable_attribute(
-                              ext_table_entry->sai_entry_oid,
-                              &generic_programmable_attr);
+        ext_table_entry->sai_entry_oid, &generic_programmable_attr);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("update sai api call failed for extension entry table %s, entry %s",
-      	                app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
+                       app_db_entry.table_name.c_str(), ext_table_entry->table_key.c_str());
         return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "update sai api call failed for extension entry table "
-                           << app_db_entry.table_name.c_str()
-                           << " , entry " << ext_table_entry->table_key.c_str();
+               << "update sai api call failed for extension entry table " << app_db_entry.table_name.c_str()
+               << " , entry " << ext_table_entry->table_key.c_str();
     }
-
 
     old_action_dep_objects = ext_table_entry->action_dep_objects;
     ext_table_entry->action_dep_objects.clear();
 
     for (auto action_dep_object_it = app_db_entry.action_dep_objects.begin();
-              action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != app_db_entry.action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->increaseRefCount(action_dep_object.sai_object, action_dep_object.key);
@@ -556,7 +542,7 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     }
 
     for (auto old_action_dep_object_it = old_action_dep_objects.begin();
-              old_action_dep_object_it != old_action_dep_objects.end(); old_action_dep_object_it++)
+         old_action_dep_object_it != old_action_dep_objects.end(); old_action_dep_object_it++)
     {
         auto old_action_dep_object = old_action_dep_object_it->second;
         m_p4OidMapper->decreaseRefCount(old_action_dep_object.sai_object, old_action_dep_object.key);
@@ -565,8 +551,7 @@ ReturnCode ExtTablesManager::updateP4ExtTableEntry(const P4ExtTableAppDbEntry &a
     return ReturnCode();
 }
 
-ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name,
-                                              const std::string &table_key)
+ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name, const std::string &table_key)
 {
     ReturnCode status;
     sai_object_type_t object_type;
@@ -578,35 +563,30 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     if (!ext_table_entry)
     {
         LOG_ERROR_AND_RETURN(ReturnCode(StatusCode::SWSS_RC_NOT_FOUND)
-                             << "extension entry with key " << QuotedVar(table_key)
-                             << " does not exist for table " << QuotedVar(table_name));
+                             << "extension entry with key " << QuotedVar(table_key) << " does not exist for table "
+                             << QuotedVar(table_name));
     }
 
     if (ext_table_entry->sai_entry_oid == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_ERROR("remove sai api call for NULL extension entry table %s, entry %s",
-      	                table_name.c_str(), table_key.c_str());
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "remove sai api call for NULL extension entry table "
-                           << table_name.c_str() << " , entry " << table_key.c_str();
+        SWSS_LOG_ERROR("remove sai api call for NULL extension entry table %s, entry %s", table_name.c_str(),
+                       table_key.c_str());
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "remove sai api call for NULL extension entry table "
+                                                             << table_name.c_str() << " , entry " << table_key.c_str();
     }
 
-    SWSS_LOG_ERROR("table: %s, key: %s", ext_table_entry->table_name.c_str(),
-                                         ext_table_entry->table_key.c_str());
-    sai_status_t sai_status = sai_generic_programmable_api->remove_generic_programmable(
-                              ext_table_entry->sai_entry_oid);
+    SWSS_LOG_ERROR("table: %s, key: %s", ext_table_entry->table_name.c_str(), ext_table_entry->table_key.c_str());
+    sai_status_t sai_status = sai_generic_programmable_api->remove_generic_programmable(ext_table_entry->sai_entry_oid);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("remove sai api call failed for extension entry table %s, entry %s",
-      	                table_name.c_str(), table_key.c_str());
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                           << "remove sai api call failed for extension entry table "
-                           << table_name.c_str() << " , entry " << table_key.c_str();
+        SWSS_LOG_ERROR("remove sai api call failed for extension entry table %s, entry %s", table_name.c_str(),
+                       table_key.c_str());
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "remove sai api call failed for extension entry table "
+                                                             << table_name.c_str() << " , entry " << table_key.c_str();
     }
     std::string crm_table_name = "EXT_" + table_name;
     boost::algorithm::to_upper(crm_table_name);
     gCrmOrch->decCrmExtTableUsedCounter(CrmResourceType::CRM_EXT_TABLE, crm_table_name);
-
 
     auto ext_table_key = KeyGenerator::generateExtTableKey(table_name, table_key);
     status = getSaiObject(ext_table_key, object_type, key);
@@ -630,7 +610,7 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     m_p4OidMapper->eraseOID(object_type, key);
 
     for (auto action_dep_object_it = ext_table_entry->action_dep_objects.begin();
-              action_dep_object_it != ext_table_entry->action_dep_objects.end(); action_dep_object_it++)
+         action_dep_object_it != ext_table_entry->action_dep_objects.end(); action_dep_object_it++)
     {
         auto action_dep_object = action_dep_object_it->second;
         m_p4OidMapper->decreaseRefCount(action_dep_object.sai_object, action_dep_object.key);
@@ -647,7 +627,6 @@ ReturnCode ExtTablesManager::removeP4ExtTableEntry(const std::string &table_name
     return ReturnCode();
 }
 
-
 ReturnCode ExtTablesManager::processAddRequest(const P4ExtTableAppDbEntry &app_db_entry)
 {
     SWSS_LOG_ENTER();
@@ -662,15 +641,14 @@ ReturnCode ExtTablesManager::processAddRequest(const P4ExtTableAppDbEntry &app_d
 }
 
 ReturnCode ExtTablesManager::processUpdateRequest(const P4ExtTableAppDbEntry &app_db_entry,
-                                               P4ExtTableEntry *ext_table_entry)
+                                                  P4ExtTableEntry *ext_table_entry)
 {
     SWSS_LOG_ENTER();
 
     auto status = updateP4ExtTableEntry(app_db_entry, ext_table_entry);
     if (!status.ok())
     {
-        SWSS_LOG_ERROR("Failed to update extension entry with key %s",
-       	                app_db_entry.table_key.c_str());
+        SWSS_LOG_ERROR("Failed to update extension entry with key %s", app_db_entry.table_key.c_str());
     }
     return ReturnCode();
 }
@@ -682,14 +660,13 @@ ReturnCode ExtTablesManager::processDeleteRequest(const P4ExtTableAppDbEntry &ap
     auto status = removeP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
     if (!status.ok())
     {
-        SWSS_LOG_ERROR("Failed to remove extension entry with key %s",
-       	                app_db_entry.table_key.c_str());
+        SWSS_LOG_ERROR("Failed to remove extension entry with key %s", app_db_entry.table_key.c_str());
     }
     return ReturnCode();
 }
 
-
-ReturnCode ExtTablesManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode ExtTablesManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                          std::string &object_key)
 {
     object_type = SAI_OBJECT_TYPE_GENERIC_PROGRAMMABLE;
     object_key = json_key;
@@ -707,97 +684,99 @@ void ExtTablesManager::drain()
     SWSS_LOG_ENTER();
     std::string table_prefix = "EXT_";
 
-    if (gP4Orch->tablesinfo) {
-      for (auto table_it = gP4Orch->tablesinfo->m_tablePrecedenceMap.begin();
-                table_it != gP4Orch->tablesinfo->m_tablePrecedenceMap.end(); ++table_it)
-      {
-        auto table_name = table_prefix + table_it->second;
-        boost::algorithm::to_upper(table_name);
-        auto it_m = m_entriesTables.find(table_name);
-        if (it_m == m_entriesTables.end())
+    if (gP4Orch->tablesinfo)
+    {
+        for (auto table_it = gP4Orch->tablesinfo->m_tablePrecedenceMap.begin();
+             table_it != gP4Orch->tablesinfo->m_tablePrecedenceMap.end(); ++table_it)
         {
-            continue;
-        }
-
-        for (const auto &key_op_fvs_tuple : it_m->second)
-        {
-            std::string table_name;
-            std::string table_key;
-
-            parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &table_key);
-            const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
-
-            if (table_name.rfind(table_prefix, 0) == std::string::npos)
+            auto table_name = table_prefix + table_it->second;
+            boost::algorithm::to_upper(table_name);
+            auto it_m = m_entriesTables.find(table_name);
+            if (it_m == m_entriesTables.end())
             {
-                SWSS_LOG_ERROR("Table %s is without prefix %s", table_name.c_str(), table_prefix.c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     StatusCode::SWSS_RC_INVALID_PARAM, /*replace=*/true);
-                continue;
-            }
-            table_name = table_name.substr(table_prefix.length());
-            boost::algorithm::to_lower(table_name);
-
-            ReturnCode status;
-            auto app_db_entry_or = deserializeP4ExtTableEntry(table_name, table_key, attributes);
-            if (!app_db_entry_or.ok())
-            {
-                status = app_db_entry_or.status();
-                SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     status, /*replace=*/true);
                 continue;
             }
 
-            auto &app_db_entry = *app_db_entry_or;
-            status = validateP4ExtTableAppDbEntry(app_db_entry);
-            if (!status.ok())
+            for (const auto &key_op_fvs_tuple : it_m->second)
             {
-                SWSS_LOG_ERROR("Validation failed for extension APP DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                     status, /*replace=*/true);
-                continue;
-            }
+                std::string table_name;
+                std::string table_key;
 
-            const std::string &operation = kfvOp(key_op_fvs_tuple);
-            if (operation == SET_COMMAND)
-            {
-                auto *ext_table_entry = getP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
-                if (ext_table_entry == nullptr)
+                parseP4RTKey(kfvKey(key_op_fvs_tuple), &table_name, &table_key);
+                const std::vector<swss::FieldValueTuple> &attributes = kfvFieldsValues(key_op_fvs_tuple);
+
+                if (table_name.rfind(table_prefix, 0) == std::string::npos)
                 {
-                    // Create extension entry
-                    app_db_entry.db_key = kfvKey(key_op_fvs_tuple);
-                    status = processAddRequest(app_db_entry);
+                    SWSS_LOG_ERROR("Table %s is without prefix %s", table_name.c_str(), table_prefix.c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), StatusCode::SWSS_RC_INVALID_PARAM,
+                                         /*replace=*/true);
+                    continue;
+                }
+                table_name = table_name.substr(table_prefix.length());
+                boost::algorithm::to_lower(table_name);
+
+                ReturnCode status;
+                auto app_db_entry_or = deserializeP4ExtTableEntry(table_name, table_key, attributes);
+                if (!app_db_entry_or.ok())
+                {
+                    status = app_db_entry_or.status();
+                    SWSS_LOG_ERROR("Unable to deserialize APP DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                    continue;
+                }
+
+                auto &app_db_entry = *app_db_entry_or;
+                status = validateP4ExtTableAppDbEntry(app_db_entry);
+                if (!status.ok())
+                {
+                    SWSS_LOG_ERROR("Validation failed for extension APP DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                    m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple),
+                                         kfvFieldsValues(key_op_fvs_tuple), status, /*replace=*/true);
+                    continue;
+                }
+
+                const std::string &operation = kfvOp(key_op_fvs_tuple);
+                if (operation == SET_COMMAND)
+                {
+                    auto *ext_table_entry = getP4ExtTableEntry(app_db_entry.table_name, app_db_entry.table_key);
+                    if (ext_table_entry == nullptr)
+                    {
+                        // Create extension entry
+                        app_db_entry.db_key = kfvKey(key_op_fvs_tuple);
+                        status = processAddRequest(app_db_entry);
+                    }
+                    else
+                    {
+                        // Modify existing extension entry
+                        status = processUpdateRequest(app_db_entry, ext_table_entry);
+                    }
+                }
+                else if (operation == DEL_COMMAND)
+                {
+                    // Delete extension entry
+                    status = processDeleteRequest(app_db_entry);
                 }
                 else
                 {
-                    // Modify existing extension entry
-                    status = processUpdateRequest(app_db_entry, ext_table_entry);
+                    status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
+                             << "Unknown operation type " << QuotedVar(operation);
+                    SWSS_LOG_ERROR("%s", status.message().c_str());
                 }
+                if (!status.ok())
+                {
+                    SWSS_LOG_ERROR("Processing failed for extension APP_DB entry with key %s: %s",
+                                   QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
+                }
+                m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
+                                     status, /*replace=*/true);
             }
-            else if (operation == DEL_COMMAND)
-            {
-                // Delete extension entry
-                status = processDeleteRequest(app_db_entry);
-            }
-            else
-            {
-                status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-       	                   << "Unknown operation type " << QuotedVar(operation);
-                SWSS_LOG_ERROR("%s", status.message().c_str());
-            }
-            if (!status.ok())
-            {
-                SWSS_LOG_ERROR("Processing failed for extension APP_DB entry with key %s: %s",
-                               QuotedVar(kfvKey(key_op_fvs_tuple)).c_str(), status.message().c_str());
-            }
-            m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                                 status, /*replace=*/true);
-        }
 
-        it_m->second.clear();
-      }
+            it_m->second.clear();
+        }
     }
 
     // Now report error for all remaining un-processed entries
@@ -813,7 +792,6 @@ void ExtTablesManager::drain()
     }
 }
 
-
 void ExtTablesManager::doExtCounterStatsTask()
 {
     SWSS_LOG_ENTER();
@@ -823,12 +801,12 @@ void ExtTablesManager::doExtCounterStatsTask()
         return;
     }
 
-    sai_stat_id_t stat_ids[] = { SAI_COUNTER_STAT_PACKETS, SAI_COUNTER_STAT_BYTES };
+    sai_stat_id_t stat_ids[] = {SAI_COUNTER_STAT_PACKETS, SAI_COUNTER_STAT_BYTES};
     uint64_t stats[2];
     std::vector<swss::FieldValueTuple> counter_stats_values;
 
     for (auto table_it = gP4Orch->tablesinfo->m_tableInfoMap.begin();
-              table_it != gP4Orch->tablesinfo->m_tableInfoMap.end(); ++table_it)
+         table_it != gP4Orch->tablesinfo->m_tableInfoMap.end(); ++table_it)
     {
         if (!table_it->second.counter_bytes_enabled && !table_it->second.counter_packets_enabled)
         {
@@ -842,8 +820,8 @@ void ExtTablesManager::doExtCounterStatsTask()
             continue;
         }
 
-        for (auto ext_table_entry_it = ext_table_it->second.begin();
-                  ext_table_entry_it != ext_table_it->second.end(); ++ext_table_entry_it)
+        for (auto ext_table_entry_it = ext_table_it->second.begin(); ext_table_entry_it != ext_table_it->second.end();
+             ++ext_table_entry_it)
         {
             auto *ext_table_entry = &ext_table_entry_it->second;
             if (ext_table_entry->sai_counter_oid == SAI_NULL_OBJECT_ID)
@@ -852,18 +830,16 @@ void ExtTablesManager::doExtCounterStatsTask()
             }
 
             sai_status_t sai_status =
-                    sai_counter_api->get_counter_stats(ext_table_entry->sai_counter_oid, 2, stat_ids, stats);
+                sai_counter_api->get_counter_stats(ext_table_entry->sai_counter_oid, 2, stat_ids, stats);
             if (sai_status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_WARN("Failed to set counters stats for extension entry %s:%s in COUNTERS_DB: ",
-       	                       table_name.c_str(), ext_table_entry->table_key.c_str());
+                              table_name.c_str(), ext_table_entry->table_key.c_str());
                 continue;
             }
 
-            counter_stats_values.push_back(
-                    swss::FieldValueTuple{P4_COUNTER_STATS_PACKETS, std::to_string(stats[0])});
-            counter_stats_values.push_back(
-                    swss::FieldValueTuple{P4_COUNTER_STATS_BYTES, std::to_string(stats[1])});
+            counter_stats_values.push_back(swss::FieldValueTuple{P4_COUNTER_STATS_PACKETS, std::to_string(stats[0])});
+            counter_stats_values.push_back(swss::FieldValueTuple{P4_COUNTER_STATS_BYTES, std::to_string(stats[1])});
 
             // Set field value tuples for counters stats in COUNTERS_DB
             m_countersTable->set(ext_table_entry->db_key, counter_stats_values);
@@ -878,4 +854,3 @@ std::string ExtTablesManager::verifyState(const std::string &key, const std::vec
 
     return result;
 }
-

--- a/orchagent/p4orch/ext_tables_manager.h
+++ b/orchagent/p4orch/ext_tables_manager.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "macaddress.h"
-#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"
@@ -15,6 +14,7 @@
 #include "response_publisher_interface.h"
 #include "return_code.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -29,9 +29,9 @@ struct P4ExtTableEntry
     sai_object_id_t sai_counter_oid = SAI_NULL_OBJECT_ID;
     std::unordered_map<std::string, DepObject> action_dep_objects;
 
-    P4ExtTableEntry() {};
+    P4ExtTableEntry(){};
     P4ExtTableEntry(const std::string &db_key, const std::string &table_name, const std::string &table_key)
-            : db_key(db_key), table_name(table_name), table_key(table_key)
+        : db_key(db_key), table_name(table_name), table_key(table_key)
     {
     }
 };
@@ -44,10 +44,9 @@ class ExtTablesManager : public ObjectManagerInterface
 {
   public:
     ExtTablesManager(P4OidMapper *p4oidMapper, VRFOrch *vrfOrch, ResponsePublisherInterface *publisher)
-      : m_vrfOrch(vrfOrch),
-        m_countersDb(std::make_unique<swss::DBConnector>("COUNTERS_DB", 0)),
-        m_countersTable(std::make_unique<swss::Table>(
-            m_countersDb.get(), std::string(COUNTERS_TABLE) + DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME))
+        : m_vrfOrch(vrfOrch), m_countersDb(std::make_unique<swss::DBConnector>("COUNTERS_DB", 0)),
+          m_countersTable(std::make_unique<swss::Table>(
+              m_countersDb.get(), std::string(COUNTERS_TABLE) + DEFAULT_KEY_SEPARATOR + APP_P4RT_TABLE_NAME))
     {
         SWSS_LOG_ENTER();
 
@@ -61,21 +60,20 @@ class ExtTablesManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // For every extension entry, update counters stats in COUNTERS_DB, if
     // counters are enabled for those entries
     void doExtCounterStatsTask();
 
   private:
-    ReturnCodeOr<P4ExtTableAppDbEntry> deserializeP4ExtTableEntry(
-        const std::string &table_name,
-        const std::string &key, const std::vector<swss::FieldValueTuple> &attributes);
+    ReturnCodeOr<P4ExtTableAppDbEntry> deserializeP4ExtTableEntry(const std::string &table_name, const std::string &key,
+                                                                  const std::vector<swss::FieldValueTuple> &attributes);
     ReturnCode validateActionParamsCrossRef(P4ExtTableAppDbEntry &app_db_entry, ActionInfo *action);
     ReturnCode validateP4ExtTableAppDbEntry(P4ExtTableAppDbEntry &app_db_entry);
     P4ExtTableEntry *getP4ExtTableEntry(const std::string &table_name, const std::string &table_key);
-    ReturnCode prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry,
-                                        std::string &ext_table_entry_attr);
+    ReturnCode prepareP4SaiExtAPIParams(const P4ExtTableAppDbEntry &app_db_entry, std::string &ext_table_entry_attr);
     ReturnCode createP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry, P4ExtTableEntry &ext_table_entry);
     ReturnCode updateP4ExtTableEntry(const P4ExtTableAppDbEntry &app_db_entry, P4ExtTableEntry *ext_table_entry);
     ReturnCode removeP4ExtTableEntry(const std::string &table_name, const std::string &table_key);

--- a/orchagent/p4orch/gre_tunnel_manager.cpp
+++ b/orchagent/p4orch/gre_tunnel_manager.cpp
@@ -9,12 +9,12 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -98,7 +98,8 @@ P4GreTunnelEntry::P4GreTunnelEntry(const std::string &tunnel_id, const std::stri
     tunnel_key = KeyGenerator::generateTunnelKey(tunnel_id);
 }
 
-ReturnCode GreTunnelManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode GreTunnelManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                          std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/gre_tunnel_manager.h
+++ b/orchagent/p4orch/gre_tunnel_manager.h
@@ -72,7 +72,8 @@ class GreTunnelManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     ReturnCodeOr<const P4GreTunnelEntry> getConstGreTunnelEntry(const std::string &gre_tunnel_key);
 

--- a/orchagent/p4orch/l3_admit_manager.cpp
+++ b/orchagent/p4orch/l3_admit_manager.cpp
@@ -7,7 +7,6 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
@@ -15,6 +14,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -64,7 +64,8 @@ ReturnCodeOr<std::vector<sai_attribute_t>> getSaiAttrs(const P4L3AdmitEntry &l3_
 
 } // namespace
 
-ReturnCode L3AdmitManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode L3AdmitManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/l3_admit_manager.h
+++ b/orchagent/p4orch/l3_admit_manager.h
@@ -63,7 +63,8 @@ class L3AdmitManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Gets the internal cached next hop entry by its key.

--- a/orchagent/p4orch/mirror_session_manager.cpp
+++ b/orchagent/p4orch/mirror_session_manager.cpp
@@ -4,13 +4,13 @@
 
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
 #include "sai_serialize.h"
 #include "swss/logger.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -21,13 +21,14 @@ extern sai_object_id_t gSwitchId;
 namespace p4orch
 {
 
-ReturnCode MirrorSessionManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode MirrorSessionManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                              std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kMirrorSessionId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kMirrorSessionId)).get<std::string>();

--- a/orchagent/p4orch/mirror_session_manager.h
+++ b/orchagent/p4orch/mirror_session_manager.h
@@ -87,7 +87,8 @@ class MirrorSessionManager : public ObjectManagerInterface
 
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
 
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4MirrorSessionAppDbEntry> deserializeP4MirrorSessionAppDbEntry(

--- a/orchagent/p4orch/neighbor_manager.cpp
+++ b/orchagent/p4orch/neighbor_manager.cpp
@@ -7,13 +7,13 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -324,14 +324,15 @@ ReturnCode NeighborManager::processDeleteRequest(const std::string &neighbor_key
     return status;
 }
 
-ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                         std::string &object_key)
 {
-    std::string     router_intf_id, neighbor_id;
+    std::string router_intf_id, neighbor_id;
     swss::IpAddress neighbor;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kRouterInterfaceId)) != j.end())
         {
             router_intf_id = j.at(prependMatchField(p4orch::kRouterInterfaceId)).get<std::string>();
@@ -350,7 +351,8 @@ ReturnCode NeighborManager::getSaiObject(const std::string &json_key, sai_object
         }
         else
         {
-            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query", p4orch::kRouterInterfaceId);
+            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query",
+                           p4orch::kRouterInterfaceId);
         }
     }
     catch (std::exception &ex)

--- a/orchagent/p4orch/neighbor_manager.h
+++ b/orchagent/p4orch/neighbor_manager.h
@@ -52,7 +52,8 @@ class NeighborManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4NeighborAppDbEntry> deserializeNeighborEntry(const std::string &key,

--- a/orchagent/p4orch/next_hop_manager.cpp
+++ b/orchagent/p4orch/next_hop_manager.cpp
@@ -8,13 +8,13 @@
 #include "crmorch.h"
 #include "dbconnector.h"
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -147,13 +147,14 @@ ReturnCodeOr<std::vector<sai_attribute_t>> NextHopManager::getSaiAttrs(const P4N
     return next_hop_attrs;
 }
 
-ReturnCode NextHopManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode NextHopManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                        std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kNexthopId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kNexthopId)).get<std::string>();

--- a/orchagent/p4orch/next_hop_manager.h
+++ b/orchagent/p4orch/next_hop_manager.h
@@ -60,7 +60,8 @@ class NextHopManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Gets the internal cached next hop entry by its key.

--- a/orchagent/p4orch/object_manager_interface.h
+++ b/orchagent/p4orch/object_manager_interface.h
@@ -18,5 +18,6 @@ class ObjectManagerInterface
 
     // For sai extension objects depending on a sai object
     // return sai object id for a given table with a given key
-    virtual ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) = 0;
+    virtual ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                    std::string &object_key) = 0;
 };

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -8,17 +8,17 @@
 #include "copporch.h"
 #include "logger.h"
 #include "orch.h"
-#include "p4orch/p4orch_util.h"
-#include "p4orch/tables_definition_manager.h"
 #include "p4orch/acl_rule_manager.h"
 #include "p4orch/acl_table_manager.h"
+#include "p4orch/ext_tables_manager.h"
 #include "p4orch/gre_tunnel_manager.h"
 #include "p4orch/l3_admit_manager.h"
 #include "p4orch/neighbor_manager.h"
 #include "p4orch/next_hop_manager.h"
+#include "p4orch/p4orch_util.h"
 #include "p4orch/route_manager.h"
 #include "p4orch/router_interface_manager.h"
-#include "p4orch/ext_tables_manager.h"
+#include "p4orch/tables_definition_manager.h"
 #include "portsorch.h"
 #include "return_code.h"
 #include "sai_serialize.h"
@@ -142,7 +142,7 @@ void P4Orch::doTask(Consumer &consumer)
             else
             {
                 auto status = ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                                  << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
+                              << "Failed to find P4Orch Manager for " << table_name << " P4RT DB table";
                 SWSS_LOG_ERROR("%s", status.message().c_str());
                 m_publisher.publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
                                     status);

--- a/orchagent/p4orch/p4orch.h
+++ b/orchagent/p4orch/p4orch.h
@@ -10,9 +10,9 @@
 #include "notificationconsumer.h"
 #include "notifier.h"
 #include "orch.h"
-#include "p4orch/tables_definition_manager.h"
 #include "p4orch/acl_rule_manager.h"
 #include "p4orch/acl_table_manager.h"
+#include "p4orch/ext_tables_manager.h"
 #include "p4orch/gre_tunnel_manager.h"
 #include "p4orch/l3_admit_manager.h"
 #include "p4orch/mirror_session_manager.h"
@@ -22,22 +22,21 @@
 #include "p4orch/p4oidmapper.h"
 #include "p4orch/route_manager.h"
 #include "p4orch/router_interface_manager.h"
+#include "p4orch/tables_definition_manager.h"
 #include "p4orch/wcmp_manager.h"
-#include "p4orch/ext_tables_manager.h"
 #include "response_publisher.h"
 #include "vrforch.h"
 
 static const std::map<std::string, std::string> FixedTablesMap = {
-    {"router_interface_table", APP_P4RT_ROUTER_INTERFACE_TABLE_NAME },
-    {"neighbor_table",         APP_P4RT_NEIGHBOR_TABLE_NAME},
-    {"nexthop_table",          APP_P4RT_NEXTHOP_TABLE_NAME},
-    {"wcmp_group_table",       APP_P4RT_WCMP_GROUP_TABLE_NAME},
-    {"ipv4_table",             APP_P4RT_IPV4_TABLE_NAME},
-    {"ipv6_table",             APP_P4RT_IPV6_TABLE_NAME},
-    {"mirror_session_table",   APP_P4RT_MIRROR_SESSION_TABLE_NAME},
-    {"l3_admit_table",         APP_P4RT_L3_ADMIT_TABLE_NAME},
-    {"tunnel_table",           APP_P4RT_TUNNEL_TABLE_NAME}
-};
+    {"router_interface_table", APP_P4RT_ROUTER_INTERFACE_TABLE_NAME},
+    {"neighbor_table", APP_P4RT_NEIGHBOR_TABLE_NAME},
+    {"nexthop_table", APP_P4RT_NEXTHOP_TABLE_NAME},
+    {"wcmp_group_table", APP_P4RT_WCMP_GROUP_TABLE_NAME},
+    {"ipv4_table", APP_P4RT_IPV4_TABLE_NAME},
+    {"ipv6_table", APP_P4RT_IPV6_TABLE_NAME},
+    {"mirror_session_table", APP_P4RT_MIRROR_SESSION_TABLE_NAME},
+    {"l3_admit_table", APP_P4RT_L3_ADMIT_TABLE_NAME},
+    {"tunnel_table", APP_P4RT_TUNNEL_TABLE_NAME}};
 
 class P4Orch : public Orch
 {
@@ -55,7 +54,6 @@ class P4Orch : public Orch
 
     // m_p4TableToManagerMap: P4 APP DB table name, P4 Object Manager
     std::unordered_map<std::string, ObjectManagerInterface *> m_p4TableToManagerMap;
- 
 
   private:
     void doTask(Consumer &consumer);

--- a/orchagent/p4orch/p4orch_util.cpp
+++ b/orchagent/p4orch/p4orch_util.cpp
@@ -1,5 +1,5 @@
-#include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "p4orch/p4orch.h"
 
 #include "schema.h"
 
@@ -116,9 +116,7 @@ ActionInfo *getTableActionInfo(TableInfo *table, const std::string &action_name)
 
 std::string KeyGenerator::generateTablesInfoKey(const std::string &context)
 {
-    std::map<std::string, std::string> fv_map = {
-            {"context", context}
-    };
+    std::map<std::string, std::string> fv_map = {{"context", context}};
     return generateKey(fv_map);
 }
 

--- a/orchagent/p4orch/p4orch_util.h
+++ b/orchagent/p4orch/p4orch_util.h
@@ -5,8 +5,8 @@
 #include <set>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "ipaddress.h"
 #include "ipprefix.h"
@@ -16,7 +16,6 @@ extern "C"
 {
 #include "saitypes.h"
 }
- 
 
 namespace p4orch
 {
@@ -110,55 +109,54 @@ std::string prependParamField(const std::string &str);
 
 struct ActionParamInfo
 {
-    std::string     name;
-    std::string     fieldtype;
-    std::string     datatype;
-    std::unordered_map<std::string, std::string>  table_reference_map;
+    std::string name;
+    std::string fieldtype;
+    std::string datatype;
+    std::unordered_map<std::string, std::string> table_reference_map;
 };
 
 struct ActionInfo
 {
-    std::string     name;
+    std::string name;
     std::unordered_map<std::string, ActionParamInfo> params;
-    bool            refers_to;
+    bool refers_to;
 };
 
 struct TableMatchInfo
 {
-    std::string        name;
-    std::string        fieldtype;
-    std::string        datatype;
-    std::unordered_map<std::string, std::string>  table_reference_map;
+    std::string name;
+    std::string fieldtype;
+    std::string datatype;
+    std::unordered_map<std::string, std::string> table_reference_map;
 };
 
 /**
- * Dervied table definition 
+ * Dervied table definition
  * This is a derived state out of table definition provided by P4RT-APP
  */
 struct TableInfo
 {
-    std::string                                      name;
-    int                                              id;
-    int                                              precedence;
-    std::unordered_map<std::string, TableMatchInfo>  match_fields;
-    std::unordered_map<std::string, ActionInfo>      action_fields;
-    bool                                             counter_bytes_enabled;
-    bool                                             counter_packets_enabled;
-    std::vector<std::string>                         action_ref_tables;
-                                                     // list of tables across all actions, of current table, refer to
+    std::string name;
+    int id;
+    int precedence;
+    std::unordered_map<std::string, TableMatchInfo> match_fields;
+    std::unordered_map<std::string, ActionInfo> action_fields;
+    bool counter_bytes_enabled;
+    bool counter_packets_enabled;
+    std::vector<std::string> action_ref_tables;
+    // list of tables across all actions, of current table, refer to
 };
 
 /**
  * table-name to table-definition map
  */
-typedef std::unordered_map<std::string, TableInfo>   TableInfoMap;
+typedef std::unordered_map<std::string, TableInfo> TableInfoMap;
 
 struct TablesInfoAppDbEntry
 {
     std::string context;
     std::string info;
 };
-
 
 struct P4RouterInterfaceAppDbEntry
 {
@@ -296,8 +294,8 @@ struct P4AclRuleAppDbEntry
 struct DepObject
 {
     sai_object_type_t sai_object;
-    std::string       key;
-    sai_object_id_t   oid;
+    std::string key;
+    sai_object_id_t oid;
 };
 
 struct P4ExtTableAppDbEntry
@@ -308,7 +306,6 @@ struct P4ExtTableAppDbEntry
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>> action_params;
     std::unordered_map<std::string, DepObject> action_dep_objects;
 };
-
 
 TableInfo *getTableInfo(const std::string &table_name);
 ActionInfo *getTableActionInfo(TableInfo *table, const std::string &action_name);

--- a/orchagent/p4orch/route_manager.cpp
+++ b/orchagent/p4orch/route_manager.cpp
@@ -11,12 +11,12 @@
 #include "converter.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "sai_serialize.h"
 #include "swssnet.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -837,7 +837,8 @@ std::vector<ReturnCode> RouteManager::deleteRouteEntries(const std::vector<P4Rou
     return statuses;
 }
 
-ReturnCode RouteManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode RouteManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                      std::string &object_key)
 {
     return StatusCode::SWSS_RC_UNIMPLEMENTED;
 }

--- a/orchagent/p4orch/route_manager.h
+++ b/orchagent/p4orch/route_manager.h
@@ -86,7 +86,8 @@ class RouteManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     // Applies route entry updates from src to dest. The merged result will be

--- a/orchagent/p4orch/router_interface_manager.cpp
+++ b/orchagent/p4orch/router_interface_manager.cpp
@@ -10,7 +10,6 @@
 #include "SaiAttributeList.h"
 #include "dbconnector.h"
 #include "directory.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "orch.h"
 #include "p4orch/p4orch_util.h"
@@ -18,6 +17,7 @@
 #include "sai_serialize.h"
 #include "table.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 
@@ -337,13 +337,14 @@ ReturnCode RouterInterfaceManager::processDeleteRequest(const std::string &route
     return status;
 }
 
-ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                                std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kRouterInterfaceId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kRouterInterfaceId)).get<std::string>();
@@ -353,7 +354,8 @@ ReturnCode RouterInterfaceManager::getSaiObject(const std::string &json_key, sai
         }
         else
         {
-            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query", p4orch::kRouterInterfaceId);
+            SWSS_LOG_ERROR("%s match parameter absent: required for dependent object query",
+                           p4orch::kRouterInterfaceId);
         }
     }
     catch (std::exception &ex)

--- a/orchagent/p4orch/router_interface_manager.h
+++ b/orchagent/p4orch/router_interface_manager.h
@@ -52,7 +52,8 @@ class RouterInterfaceManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
     ReturnCodeOr<P4RouterInterfaceAppDbEntry> deserializeRouterIntfEntry(

--- a/orchagent/p4orch/tables_definition_manager.cpp
+++ b/orchagent/p4orch/tables_definition_manager.cpp
@@ -7,30 +7,23 @@
 #include <vector>
 
 #include "directory.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
-#include "tokenize.h"
 #include "orch.h"
 #include "p4orch/p4orch.h"
 #include "p4orch/p4orch_util.h"
+#include "tokenize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "saitypes.h"
 }
 
-
 extern Directory<Orch *> gDirectory;
 extern P4Orch *gP4Orch;
-const std::map<std::string, std::string> format_datatype_map =
-{
-    {"MAC",    "SAI_ATTR_VALUE_TYPE_MAC"},
-    {"IPV4",   "SAI_ATTR_VALUE_TYPE_IPV4"},
-    {"IPV6",   "SAI_ATTR_VALUE_TYPE_IPV6"}
-};
+const std::map<std::string, std::string> format_datatype_map = {
+    {"MAC", "SAI_ATTR_VALUE_TYPE_MAC"}, {"IPV4", "SAI_ATTR_VALUE_TYPE_IPV4"}, {"IPV6", "SAI_ATTR_VALUE_TYPE_IPV6"}};
 
-
-std::string
-BitwidthToDatatype (int bitwidth)
+std::string BitwidthToDatatype(int bitwidth)
 {
     std::string datatype = "SAI_ATTR_VALUE_TYPE_CHARDATA";
 
@@ -58,8 +51,7 @@ BitwidthToDatatype (int bitwidth)
     return datatype;
 }
 
-std::string
-parseBitwidthToDatatype (const nlohmann::json &json)
+std::string parseBitwidthToDatatype(const nlohmann::json &json)
 {
     int bitwidth;
     std::string datatype = "SAI_ATTR_VALUE_TYPE_CHARDATA";
@@ -73,8 +65,7 @@ parseBitwidthToDatatype (const nlohmann::json &json)
     return datatype;
 }
 
-std::string
-parseFormatToDatatype (const nlohmann::json &json, std::string datatype)
+std::string parseFormatToDatatype(const nlohmann::json &json, std::string datatype)
 {
     std::string format;
 
@@ -92,8 +83,7 @@ parseFormatToDatatype (const nlohmann::json &json, std::string datatype)
     return datatype;
 }
 
-ReturnCode
-parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &match)
+ReturnCode parseTableMatchReferences(const nlohmann::json &match_json, TableMatchInfo &match)
 {
     std::string table, field;
 
@@ -110,7 +100,7 @@ parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &mat
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -118,8 +108,7 @@ parseTableMatchReferences (const nlohmann::json &match_json, TableMatchInfo &mat
     return ReturnCode();
 }
 
-ReturnCode
-parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &param)
+ReturnCode parseActionParamReferences(const nlohmann::json &param_json, ActionParamInfo &param)
 {
     std::string table, field;
 
@@ -136,7 +125,7 @@ parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &p
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -144,8 +133,7 @@ parseActionParamReferences (const nlohmann::json &param_json, ActionParamInfo &p
     return ReturnCode();
 }
 
-ReturnCode
-parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
+ReturnCode parseTableActionParams(const nlohmann::json &action_json, ActionInfo &action)
 {
     action.refers_to = false;
     if (action_json.find(p4orch::kActionParams) != action_json.end())
@@ -175,7 +163,7 @@ parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
             catch (std::exception &ex)
             {
                 return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                       << "can not parse tables from app-db supplied table definition info";
             }
         }
     }
@@ -183,8 +171,7 @@ parseTableActionParams (const nlohmann::json &action_json, ActionInfo &action)
     return ReturnCode();
 }
 
-ReturnCode
-parseTableCounter (const nlohmann::json &table_json, TableInfo &table)
+ReturnCode parseTableCounter(const nlohmann::json &table_json, TableInfo &table)
 {
     if (table_json.find(p4orch::kCounterUnit) != table_json.end())
     {
@@ -207,8 +194,7 @@ parseTableCounter (const nlohmann::json &table_json, TableInfo &table)
     return ReturnCode();
 }
 
-ReturnCode
-parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
+ReturnCode parseTablesInfo(const nlohmann::json &info_json, TablesInfo &info_entry)
 {
     ReturnCode status;
     int table_id;
@@ -216,8 +202,7 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
     if (info_json.find(p4orch::kTables) == info_json.end())
     {
-        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-       	         << "no tables in app-db supplied table definition info";
+        return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM) << "no tables in app-db supplied table definition info";
     }
 
     for (const auto &table_json : info_json[p4orch::kTables])
@@ -230,18 +215,17 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
         catch (std::exception &ex)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse tables from app-db supplied table definition info";
+                   << "can not parse tables from app-db supplied table definition info";
         }
 
-
-	TableInfo table = {};
+        TableInfo table = {};
         table.name = table_name;
-        table.id   = table_id;
+        table.id = table_id;
         try
         {
             for (const auto &match_json : table_json[p4orch::kmatchFields])
             {
-		TableMatchInfo match = {};
+                TableMatchInfo match = {};
                 std::string match_name;
 
                 match_name = match_json.at(p4orch::kName).get<std::string>();
@@ -254,7 +238,7 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
             for (const auto &action_json : table_json[p4orch::kActions])
             {
-		ActionInfo action = {};
+                ActionInfo action = {};
                 std::string action_name;
 
                 action_name = action_json.at(p4orch::kAlias).get<std::string>();
@@ -266,20 +250,18 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
                  * If any parameter of action refers to another table, add that one in the
                  * cross-reference list of current table
                  */
-                for (auto param_it = action.params.begin();
-                          param_it != action.params.end(); param_it++)
+                for (auto param_it = action.params.begin(); param_it != action.params.end(); param_it++)
                 {
                     ActionParamInfo action_param = param_it->second;
                     for (auto ref_it = action_param.table_reference_map.begin();
-                              ref_it != action_param.table_reference_map.end(); ref_it++)
+                         ref_it != action_param.table_reference_map.end(); ref_it++)
                     {
-                        if (std::find(table.action_ref_tables.begin(),
-                                      table.action_ref_tables.end(),
-                                      ref_it->first) == table.action_ref_tables.end())
+                        if (std::find(table.action_ref_tables.begin(), table.action_ref_tables.end(), ref_it->first) ==
+                            table.action_ref_tables.end())
                         {
                             table.action_ref_tables.push_back(ref_it->first);
                         }
-                   }
+                    }
                 }
             }
 
@@ -288,9 +270,8 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
         catch (std::exception &ex)
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                     << "can not parse table " << QuotedVar(table_name.c_str()) << "match fields";
+                   << "can not parse table " << QuotedVar(table_name.c_str()) << "match fields";
         }
-
 
         info_entry.m_tableIdNameMap[std::to_string(table_id)] = table_name;
         info_entry.m_tableInfoMap[table_name] = table;
@@ -298,7 +279,6 @@ parseTablesInfo (const nlohmann::json &info_json, TablesInfo &info_entry)
 
     return ReturnCode();
 }
-
 
 ReturnCodeOr<TablesInfoAppDbEntry> TablesDefnManager::deserializeTablesInfoEntry(
     const std::string &key, const std::vector<swss::FieldValueTuple> &attributes)
@@ -327,7 +307,7 @@ ReturnCodeOr<TablesInfoAppDbEntry> TablesDefnManager::deserializeTablesInfoEntry
         else
         {
             return ReturnCode(StatusCode::SWSS_RC_INVALID_PARAM)
-                       << "Unexpected field " << QuotedVar(field) << " in table entry";
+                   << "Unexpected field " << QuotedVar(field) << " in table entry";
         }
     }
 
@@ -416,14 +396,13 @@ ReturnCode TablesDefnManager::processDeleteRequest(const std::string &context_ke
     return ReturnCode();
 }
 
-ReturnCode TablesDefnManager::getSaiObject(const std::string &json_key,
-       	                                   sai_object_type_t &object_type, std::string &object_key)
+ReturnCode TablesDefnManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                           std::string &object_key)
 {
     return StatusCode::SWSS_RC_INVALID_PARAM;
 }
 
-std::unordered_map<int, std::unordered_set<int>>
-createGraph (std::vector<std::pair<int, int>> preReq)
+std::unordered_map<int, std::unordered_set<int>> createGraph(std::vector<std::pair<int, int>> preReq)
 {
     std::unordered_map<int, std::unordered_set<int>> graph;
 
@@ -443,8 +422,7 @@ createGraph (std::vector<std::pair<int, int>> preReq)
     return graph;
 }
 
-std::unordered_map<int, int>
-computeIndegree (std::unordered_map<int, std::unordered_set<int>> &graph)
+std::unordered_map<int, int> computeIndegree(std::unordered_map<int, std::unordered_set<int>> &graph)
 {
     std::unordered_map<int, int> degrees;
 
@@ -467,19 +445,16 @@ computeIndegree (std::unordered_map<int, std::unordered_set<int>> &graph)
     return degrees;
 }
 
-
-std::vector<int>
-findTablePrecedence (int tables, std::vector<std::pair<int, int>> preReq, TablesInfo *tables_info)
+std::vector<int> findTablePrecedence(int tables, std::vector<std::pair<int, int>> preReq, TablesInfo *tables_info)
 {
     std::unordered_map<int, std::unordered_set<int>> graph = createGraph(preReq);
     std::unordered_map<int, int> degrees = computeIndegree(graph);
     std::vector<int> visited;
     std::vector<int> toposort;
-    std::queue<int>  zeros;
+    std::queue<int> zeros;
 
     // initialize queue with tables having no dependencies
-    for (auto table_it = tables_info->m_tableInfoMap.begin();
-              table_it != tables_info->m_tableInfoMap.end(); table_it++)
+    for (auto table_it = tables_info->m_tableInfoMap.begin(); table_it != tables_info->m_tableInfoMap.end(); table_it++)
     {
         TableInfo table_info = table_it->second;
         if (degrees.find(table_info.id) == degrees.end())
@@ -530,21 +505,19 @@ findTablePrecedence (int tables, std::vector<std::pair<int, int>> preReq, Tables
     return toposort;
 }
 
-
-void
-buildTablePrecedence (TablesInfo *tables_info)
+void buildTablePrecedence(TablesInfo *tables_info)
 {
     std::vector<std::pair<int, int>> preReq;
     std::vector<int> orderedTables;
     int tables = 0;
 
-    if (!tables_info) {
+    if (!tables_info)
+    {
         return;
     }
 
     // build dependencies
-    for (auto table_it = tables_info->m_tableInfoMap.begin();
-              table_it != tables_info->m_tableInfoMap.end(); table_it++)
+    for (auto table_it = tables_info->m_tableInfoMap.begin(); table_it != tables_info->m_tableInfoMap.end(); table_it++)
     {
         TableInfo table_info = table_it->second;
         tables++;
@@ -552,18 +525,18 @@ buildTablePrecedence (TablesInfo *tables_info)
         for (std::size_t i = 0; i < table_info.action_ref_tables.size(); i++)
         {
             /**
-	     * For now processing precedence order is only amongst extension tables
-	     * Skip fixed tables, include them in precedence calculations when fixed
-	     * and extension tables processing precedence may be interleaved
-	     */
+             * For now processing precedence order is only amongst extension tables
+             * Skip fixed tables, include them in precedence calculations when fixed
+             * and extension tables processing precedence may be interleaved
+             */
             if (FixedTablesMap.find(table_info.action_ref_tables[i]) != FixedTablesMap.end())
             {
                 continue;
             }
 
             TableInfo ref_table_info = tables_info->m_tableInfoMap[table_info.action_ref_tables[i]];
-            if (std::find(preReq.begin(), preReq.end(),
-                          std::make_pair(table_info.id, ref_table_info.id)) == preReq.end())
+            if (std::find(preReq.begin(), preReq.end(), std::make_pair(table_info.id, ref_table_info.id)) ==
+                preReq.end())
             {
                 preReq.push_back(std::make_pair(table_info.id, ref_table_info.id));
             }
@@ -595,7 +568,6 @@ buildTablePrecedence (TablesInfo *tables_info)
 
     return;
 }
-
 
 void TablesDefnManager::enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry)
 {
@@ -672,8 +644,8 @@ void TablesDefnManager::drain()
         {
             buildTablePrecedence(gP4Orch->tablesinfo);
         }
-        m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple),
-                             status, /*replace=*/true);
+        m_publisher->publish(APP_P4RT_TABLE_NAME, kfvKey(key_op_fvs_tuple), kfvFieldsValues(key_op_fvs_tuple), status,
+                             /*replace=*/true);
     }
     m_entries.clear();
 }

--- a/orchagent/p4orch/tables_definition_manager.h
+++ b/orchagent/p4orch/tables_definition_manager.h
@@ -6,13 +6,13 @@
 #include <vector>
 
 #include "macaddress.h"
-#include <nlohmann/json.hpp>
 #include "orch.h"
 #include "p4orch/object_manager_interface.h"
 #include "p4orch/p4oidmapper.h"
 #include "p4orch/p4orch_util.h"
 #include "response_publisher_interface.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -23,13 +23,13 @@ extern "C"
  */
 struct TablesInfo
 {
-    std::string     context;
-    nlohmann::json  info;
+    std::string context;
+    nlohmann::json info;
     std::unordered_map<std::string, std::string> m_tableIdNameMap;
     std::unordered_map<std::string, TableInfo> m_tableInfoMap;
     std::map<int, std::string> m_tablePrecedenceMap;
 
-    TablesInfo() {};
+    TablesInfo(){};
     TablesInfo(const std::string &context_key, const nlohmann::json &info_value)
         : context(context_key), info(info_value)
     {
@@ -59,11 +59,12 @@ class TablesDefnManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
   private:
-    ReturnCodeOr<TablesInfoAppDbEntry> deserializeTablesInfoEntry(
-        const std::string &key, const std::vector<swss::FieldValueTuple> &attributes);
+    ReturnCodeOr<TablesInfoAppDbEntry> deserializeTablesInfoEntry(const std::string &key,
+                                                                  const std::vector<swss::FieldValueTuple> &attributes);
     TablesInfo *getTablesInfoEntry(const std::string &context_key);
     ReturnCode createTablesInfo(const std::string &context_key, TablesInfo &tablesinfo_entry);
     ReturnCode removeTablesInfo(const std::string &context_key);

--- a/orchagent/p4orch/tests/acl_manager_test.cpp
+++ b/orchagent/p4orch/tests/acl_manager_test.cpp
@@ -9,7 +9,6 @@
 #include "acl_table_manager.h"
 #include "acl_util.h"
 #include "acltable.h"
-#include <nlohmann/json.hpp>
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_policer.h"
@@ -22,6 +21,7 @@
 #include "table.h"
 #include "tokenize.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/fake_flexcounterorch.cpp
+++ b/orchagent/p4orch/tests/fake_flexcounterorch.cpp
@@ -1,12 +1,10 @@
 #include "copporch.h"
 #include "flexcounterorch.h"
 
-FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames) :
-    Orch(db, tableNames),
-    m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
-    m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME),
-    m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
-    m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME)
+FlexCounterOrch::FlexCounterOrch(swss::DBConnector *db, std::vector<std::string> &tableNames)
+    : Orch(db, tableNames), m_flexCounterConfigTable(db, CFG_FLEX_COUNTER_TABLE_NAME),
+      m_bufferQueueConfigTable(db, CFG_BUFFER_QUEUE_TABLE_NAME), m_bufferPgConfigTable(db, CFG_BUFFER_PG_TABLE_NAME),
+      m_deviceMetadataConfigTable(db, CFG_DEVICE_METADATA_TABLE_NAME)
 {
 }
 

--- a/orchagent/p4orch/tests/fake_portorch.cpp
+++ b/orchagent/p4orch/tests/fake_portorch.cpp
@@ -185,7 +185,7 @@ void PortsOrch::generateQueueMap(std::map<string, FlexCounterQueueStates> queues
 {
 }
 
-void PortsOrch::generateQueueMapPerPort(const Port& port, FlexCounterQueueStates& queuesState, bool voq)
+void PortsOrch::generateQueueMapPerPort(const Port &port, FlexCounterQueueStates &queuesState, bool voq)
 {
 }
 
@@ -201,15 +201,15 @@ void PortsOrch::generatePriorityGroupMap(std::map<string, FlexCounterPgStates> p
 {
 }
 
-void PortsOrch::generatePriorityGroupMapPerPort(const Port& port, FlexCounterPgStates& pgsState)
+void PortsOrch::generatePriorityGroupMapPerPort(const Port &port, FlexCounterPgStates &pgsState)
 {
 }
 
-void PortsOrch::createPortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::createPortBufferPgCounters(const Port &port, string pgs)
 {
 }
 
-void PortsOrch::removePortBufferPgCounters(const Port& port, string pgs)
+void PortsOrch::removePortBufferPgCounters(const Port &port, string pgs)
 {
 }
 
@@ -591,7 +591,8 @@ bool PortsOrch::setGearboxPortsAttr(const Port &port, sai_port_attr_t id, void *
     return true;
 }
 
-bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value, bool override_fec)
+bool PortsOrch::setGearboxPortAttr(const Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value,
+                                   bool override_fec)
 {
     return true;
 }
@@ -621,7 +622,8 @@ task_process_status PortsOrch::setPortInterfaceType(Port &port, sai_port_interfa
     return task_success;
 }
 
-task_process_status PortsOrch::setPortAdvInterfaceTypes(Port &port, std::set<sai_port_interface_type_t> &interface_types)
+task_process_status PortsOrch::setPortAdvInterfaceTypes(Port &port,
+                                                        std::set<sai_port_interface_type_t> &interface_types)
 {
     return task_success;
 }

--- a/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
+++ b/orchagent/p4orch/tests/gre_tunnel_manager_test.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_router_interface.h"
 #include "mock_sai_serialize.h"
@@ -18,6 +17,7 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/l3_admit_manager_test.cpp
+++ b/orchagent/p4orch/tests/l3_admit_manager_test.cpp
@@ -7,13 +7,13 @@
 #include <string>
 #include <unordered_map>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_my_mac.h"
 #include "p4oidmapper.h"
 #include "p4orch/p4orch_util.h"
 #include "p4orch_util.h"
 #include "return_code.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/mirror_session_manager_test.cpp
+++ b/orchagent/p4orch/tests/mirror_session_manager_test.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_mirror.h"
 #include "p4oidmapper.h"
@@ -15,6 +14,7 @@
 #include "swss/ipaddress.h"
 #include "swss/macaddress.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/neighbor_manager_test.cpp
+++ b/orchagent/p4orch/tests/neighbor_manager_test.cpp
@@ -6,13 +6,13 @@
 #include <string>
 #include <unordered_set>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_neighbor.h"
 #include "p4orch.h"
 #include "p4orch/p4orch_util.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/next_hop_manager_test.cpp
+++ b/orchagent/p4orch/tests/next_hop_manager_test.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "ipaddress.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_hostif.h"
 #include "mock_sai_next_hop.h"
@@ -18,6 +17,7 @@
 #include "p4orch.h"
 #include "return_code.h"
 #include "swssnet.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/tests/route_manager_test.cpp
+++ b/orchagent/p4orch/tests/route_manager_test.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "ipprefix.h"
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_route.h"
 #include "p4orch.h"
@@ -17,6 +16,7 @@
 #include "return_code.h"
 #include "swssnet.h"
 #include "vrforch.h"
+#include <nlohmann/json.hpp>
 
 using ::p4orch::kTableKeyDelimiter;
 

--- a/orchagent/p4orch/tests/test_main.cpp
+++ b/orchagent/p4orch/tests/test_main.cpp
@@ -99,7 +99,6 @@ bool parseHandleSaiStatusFailure(task_process_status status)
     return true;
 }
 
-
 namespace
 {
 
@@ -173,7 +172,7 @@ void AddVrf()
 } // namespace
 
 int main(int argc, char *argv[])
-{   
+{
     gBatchSize = DEFAULT_BATCH_SIZE;
     testing::InitGoogleTest(&argc, argv);
 

--- a/orchagent/p4orch/tests/wcmp_manager_test.cpp
+++ b/orchagent/p4orch/tests/wcmp_manager_test.cpp
@@ -5,7 +5,6 @@
 
 #include <string>
 
-#include <nlohmann/json.hpp>
 #include "mock_response_publisher.h"
 #include "mock_sai_acl.h"
 #include "mock_sai_hostif.h"
@@ -18,6 +17,7 @@
 #include "p4orch_util.h"
 #include "return_code.h"
 #include "sai_serialize.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"

--- a/orchagent/p4orch/wcmp_manager.cpp
+++ b/orchagent/p4orch/wcmp_manager.cpp
@@ -7,12 +7,12 @@
 #include "SaiAttributeList.h"
 #include "crmorch.h"
 #include "dbconnector.h"
-#include <nlohmann/json.hpp>
 #include "logger.h"
 #include "p4orch/p4orch_util.h"
 #include "portsorch.h"
 #include "sai_serialize.h"
 #include "table.h"
+#include <nlohmann/json.hpp>
 extern "C"
 {
 #include "sai.h"
@@ -734,13 +734,14 @@ void WcmpManager::updatePortOperStatusMap(const std::string &port, const sai_por
     port_oper_status_map[port] = status;
 }
 
-ReturnCode WcmpManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key)
+ReturnCode WcmpManager::getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                                     std::string &object_key)
 {
-    std::string     value;
+    std::string value;
 
     try
     {
-        nlohmann::json  j = nlohmann::json::parse(json_key);
+        nlohmann::json j = nlohmann::json::parse(json_key);
         if (j.find(prependMatchField(p4orch::kWcmpGroupId)) != j.end())
         {
             value = j.at(prependMatchField(p4orch::kWcmpGroupId)).get<std::string>();

--- a/orchagent/p4orch/wcmp_manager.h
+++ b/orchagent/p4orch/wcmp_manager.h
@@ -72,7 +72,8 @@ class WcmpManager : public ObjectManagerInterface
     void enqueue(const std::string &table_name, const swss::KeyOpFieldsValuesTuple &entry) override;
     void drain() override;
     std::string verifyState(const std::string &key, const std::vector<swss::FieldValueTuple> &tuple) override;
-    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type, std::string &object_key) override;
+    ReturnCode getSaiObject(const std::string &json_key, sai_object_type_t &object_type,
+                            std::string &object_key) override;
 
     // Prunes next hop members egressing through the given port.
     void pruneNextHops(const std::string &port);

--- a/orchagent/port/porthlpr.cpp
+++ b/orchagent/port/porthlpr.cpp
@@ -1001,7 +1001,7 @@ bool PortHelper::parsePortConfig(PortConfig &port) const
         }
     }
 
-    return this->validatePortConfig(port);
+    return true;
 }
 
 bool PortHelper::validatePortConfig(PortConfig &port) const

--- a/orchagent/port/porthlpr.h
+++ b/orchagent/port/porthlpr.h
@@ -28,6 +28,7 @@ public:
     std::string getAdminStatusStr(const PortConfig &port) const;
 
     bool parsePortConfig(PortConfig &port) const;
+    bool validatePortConfig(PortConfig &port) const;
 
 private:
     std::string getFieldValueStr(const PortConfig &port, const std::string &field) const;
@@ -52,6 +53,4 @@ private:
     bool parsePortRole(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortAdminStatus(PortConfig &port, const std::string &field, const std::string &value) const;
     bool parsePortDescription(PortConfig &port, const std::string &field, const std::string &value) const;
-
-    bool validatePortConfig(PortConfig &port) const;
 };

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3572,28 +3572,59 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            auto &fvMap = m_portConfigMap[key];
-
-            for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
+            auto parsePortFvs = [&](auto& fvMap) -> bool
             {
-                auto fieldName = fvField(cit);
-                auto fieldValue = fvValue(cit);
+                for (const auto &cit : kfvFieldsValues(keyOpFieldsValues))
+                {
+                    auto fieldName = fvField(cit);
+                    auto fieldValue = fvValue(cit);
 
-                SWSS_LOG_INFO("FIELD: %s, VALUE: %s", fieldName.c_str(), fieldValue.c_str());
+                    SWSS_LOG_INFO("FIELD: %s, VALUE: %s", fieldName.c_str(), fieldValue.c_str());
 
-                fvMap[fieldName] = fieldValue;
-            }
+                    fvMap[fieldName] = fieldValue;
+                }
 
-            pCfg.fieldValueMap = fvMap;
+                pCfg.fieldValueMap = fvMap;
 
-            if (!m_portHlpr.parsePortConfig(pCfg))
+                if (!m_portHlpr.parsePortConfig(pCfg))
+                {
+                    return false;
+                }
+
+                return true;
+            };
+
+            if (m_portList.find(key) == m_portList.end())
             {
-                it = taskMap.erase(it);
-                continue;
-            }
+                // Aggregate configuration while the port is not created.
+                auto &fvMap = m_portConfigMap[key];
 
-            /* Collect information about all received ports */
-            m_lanesAliasSpeedMap[pCfg.lanes.value] = pCfg;
+                if (!parsePortFvs(fvMap))
+                {
+                    it = taskMap.erase(it);
+                    continue;
+                }
+
+                if (!m_portHlpr.validatePortConfig(pCfg))
+                {
+                    it = taskMap.erase(it);
+                    continue;
+                }
+
+                /* Collect information about all received ports */
+                m_lanesAliasSpeedMap[pCfg.lanes.value] = pCfg;
+            }
+            else
+            {
+                // Port is already created, gather updated field-values.
+                std::unordered_map<std::string, std::string> fvMap;
+
+                if (!parsePortFvs(fvMap))
+                {
+                    it = taskMap.erase(it);
+                    continue;
+                }
+            }
 
             // TODO:
             // Fix the issue below
@@ -3708,6 +3739,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
             {
                 PortSerdesAttrMap_t serdes_attr;
                 getPortSerdesAttr(serdes_attr, pCfg);
+
+                // Saved configured admin status
+                bool admin_status = p.m_admin_state_up;
 
                 if (pCfg.autoneg.is_set)
                 {
@@ -4268,6 +4302,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 /* create host_tx_ready field in state-db */
                 initHostTxReadyState(p);
+
+                // Restore admin status if the port was brought down
+                if (admin_status != p.m_admin_state_up)
+                {
+                    pCfg.admin_status.is_set = true;
+                    pCfg.admin_status.value = admin_status;
+                }
 
                 /* Last step set port admin status */
                 if (pCfg.admin_status.is_set)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -7779,6 +7779,18 @@ void PortsOrch::refreshPortStatus()
             {
                 updateDbPortOperSpeed(port, 0);
             }
+            sai_port_fec_mode_t fec_mode;
+            string fec_str = "N/A";
+            if (oper_fec_sup && getPortOperFec(port, fec_mode))
+            {
+                if (!m_portHlpr.fecToStr(fec_str, fec_mode))
+                {
+                    SWSS_LOG_ERROR("Error unknown fec mode %d while querying port %s fec mode",
+                                   static_cast<std::int32_t>(fec_mode), port.m_alias.c_str());
+                    fec_str = "N/A";
+                }
+            }
+            updateDbPortOperFec(port,fec_str);
         }
     }
 }

--- a/orchagent/response_publisher.cpp
+++ b/orchagent/response_publisher.cpp
@@ -50,7 +50,7 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 {
     if (!swss::Recorder::Instance().respub.isRecord())
     {
-       return;
+        return;
     }
 
     std::string s = response_channel + ":" + key + "|" + status;
@@ -64,10 +64,9 @@ void RecordResponse(const std::string &response_channel, const std::string &key,
 
 } // namespace
 
-ResponsePublisher::ResponsePublisher(bool buffered) :
-    m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)),
-    m_pipe(std::make_unique<swss::RedisPipeline>(m_db.get())),
-    m_buffered(buffered)
+ResponsePublisher::ResponsePublisher(bool buffered)
+    : m_db(std::make_unique<swss::DBConnector>("APPL_STATE_DB", 0)),
+      m_pipe(std::make_unique<swss::RedisPipeline>(m_db.get())), m_buffered(buffered)
 {
 }
 

--- a/orchagent/response_publisher.h
+++ b/orchagent/response_publisher.h
@@ -7,9 +7,9 @@
 
 #include "dbconnector.h"
 #include "notificationproducer.h"
+#include "recorder.h"
 #include "response_publisher_interface.h"
 #include "table.h"
-#include "recorder.h"
 
 // This class performs two tasks when publish is called:
 // 1. Sends a notification into the redis channel.
@@ -46,14 +46,14 @@ class ResponsePublisher : public ResponsePublisherInterface
 
     /**
      * @brief Flush pending responses
-    */
+     */
     void flush();
 
     /**
      * @brief Set buffering mode
      *
      * @param buffered Flag whether responses are buffered
-    */
+     */
     void setBuffered(bool buffered);
 
   private:

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -82,6 +82,7 @@ sai_dash_inbound_routing_api_t*     sai_dash_inbound_routing_api;
 sai_dash_eni_api_t*                 sai_dash_eni_api;
 sai_dash_vip_api_t*                 sai_dash_vip_api;
 sai_dash_direction_lookup_api_t*    sai_dash_direction_lookup_api;
+sai_twamp_api_t*                    sai_twamp_api;
 
 extern sai_object_id_t gSwitchId;
 
@@ -217,6 +218,7 @@ void initSaiApi()
     sai_api_query((sai_api_t)SAI_API_DASH_ENI,                  (void**)&sai_dash_eni_api);
     sai_api_query((sai_api_t)SAI_API_DASH_VIP,                  (void**)&sai_dash_vip_api);
     sai_api_query((sai_api_t)SAI_API_DASH_DIRECTION_LOOKUP,     (void**)&sai_dash_direction_lookup_api);
+    sai_api_query(SAI_API_TWAMP,                (void **)&sai_twamp_api);
 
     sai_log_set(SAI_API_SWITCH,                 SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_BRIDGE,                 SAI_LOG_LEVEL_NOTICE);
@@ -256,6 +258,7 @@ void initSaiApi()
     sai_log_set(SAI_API_BFD,                    SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_MY_MAC,                 SAI_LOG_LEVEL_NOTICE);
     sai_log_set(SAI_API_GENERIC_PROGRAMMABLE,   SAI_LOG_LEVEL_NOTICE);
+    sai_log_set(SAI_API_TWAMP,                  SAI_LOG_LEVEL_NOTICE);
 }
 
 void initSaiRedis()

--- a/orchagent/twamporch.cpp
+++ b/orchagent/twamporch.cpp
@@ -1,0 +1,1052 @@
+#include "twamporch.h"
+#include "vrforch.h"
+#include "crmorch.h"
+#include "logger.h"
+#include "swssnet.h"
+#include "converter.h"
+#include "sai_serialize.h"
+#include "tokenize.h"
+#include "notifier.h"
+#include "notifications.h"
+
+#include <exception>
+
+using namespace std;
+using namespace swss;
+
+/* TWAMP infor */
+#define TWAMP_SESSION_MODE                       "MODE"
+#define TWAMP_SESSION_ROLE                       "ROLE"
+#define TWAMP_SESSION_VRF_NAME                   "VRF_NAME"
+#define TWAMP_SESSION_HW_LOOKUP                  "HW_LOOKUP"
+
+/* TWAMP-test packet */
+#define TWAMP_SESSION_SRC_IP                     "SRC_IP"
+#define TWAMP_SESSION_SRC_UDP_PORT               "SRC_UDP_PORT"
+#define TWAMP_SESSION_DST_IP                     "DST_IP"
+#define TWAMP_SESSION_DST_UDP_PORT               "DST_UDP_PORT"
+#define TWAMP_SESSION_DSCP                       "DSCP"
+#define TWAMP_SESSION_TTL                        "TTL"
+#define TWAMP_SESSION_PACKET_TIMESTAMP_FORMAT    "TIMESTAMP_FORMAT"
+#define TWAMP_SESSION_PACKET_PADDING_SIZE        "PADDING_SIZE"
+
+/* Session-Sender */
+#define TWAMP_SESSION_TX_PACKET_COUNT            "PACKET_COUNT"
+#define TWAMP_SESSION_TX_MONITOR_TIME            "MONITOR_TIME"
+#define TWAMP_SESSION_TX_INTERVAL                "TX_INTERVAL"
+#define TWAMP_SESSION_TIMEOUT                    "TIMEOUT"
+#define TWAMP_SESSION_STATISTICS_INTERVAL        "STATISTICS_INTERVAL"
+#define TWAMP_SESSION_ADMIN_STATE                "ADMIN_STATE"
+
+/* TWAMP session status */
+#define TWAMP_SESSION_STATUS                "status"
+#define TWAMP_SESSION_STATUS_ACTIVE         "active"
+#define TWAMP_SESSION_STATUS_INACTIVE       "inactive"
+
+#define TWAMP_SESSION_TX_MODE_PACKET_NUM    "packet_num"
+#define TWAMP_SESSION_TX_MODE_CONTINUOUS    "continuous"
+
+#define TWAMP_SESSION_DSCP_MIN    0
+#define TWAMP_SESSION_DSCP_MAX    63
+
+#define TWAMP_SESSION_TIMEOUT_MIN    1
+#define TWAMP_SESSION_TIMEOUT_MAX    10
+
+static map<string, sai_twamp_session_role_t> twamp_role_map =
+{
+    { "SENDER",       SAI_TWAMP_SESSION_ROLE_SENDER    },
+    { "REFLECTOR",    SAI_TWAMP_SESSION_ROLE_REFLECTOR }
+};
+
+static map<string, sai_twamp_mode_t> twamp_mode_map =
+{
+    { "FULL",     SAI_TWAMP_MODE_FULL    },
+    { "LIGHT",    SAI_TWAMP_MODE_LIGHT   }
+};
+
+static map<string, sai_twamp_timestamp_format_t> timestamp_format_map =
+{
+    { "NTP",    SAI_TWAMP_TIMESTAMP_FORMAT_NTP },
+    { "PTP",    SAI_TWAMP_TIMESTAMP_FORMAT_PTP }
+};
+
+static map<string, bool> session_admin_state_map =
+{
+    { "ENABLED",  true  },
+    { "DISABLED", false }
+};
+
+static map<string, bool> hw_lookup_map =
+{
+    { "TRUE",  true  },
+    { "FALSE", false }
+};
+
+/* Global variables */
+extern sai_object_id_t     gSwitchId;
+extern sai_object_id_t     gVirtualRouterId;
+extern sai_switch_api_t   *sai_switch_api;
+extern sai_twamp_api_t    *sai_twamp_api;
+extern CrmOrch            *gCrmOrch;
+
+const vector<sai_twamp_session_stat_t> twamp_session_stat_ids =
+{
+    SAI_TWAMP_SESSION_STAT_RX_PACKETS,
+    SAI_TWAMP_SESSION_STAT_RX_BYTE,
+    SAI_TWAMP_SESSION_STAT_TX_PACKETS,
+    SAI_TWAMP_SESSION_STAT_TX_BYTE,
+    SAI_TWAMP_SESSION_STAT_DROP_PACKETS,
+    SAI_TWAMP_SESSION_STAT_MAX_LATENCY,
+    SAI_TWAMP_SESSION_STAT_MIN_LATENCY,
+    SAI_TWAMP_SESSION_STAT_AVG_LATENCY,
+    SAI_TWAMP_SESSION_STAT_MAX_JITTER,
+    SAI_TWAMP_SESSION_STAT_MIN_JITTER,
+    SAI_TWAMP_SESSION_STAT_AVG_JITTER
+};
+
+
+
+TwampOrch::TwampOrch(TableConnector confDbConnector, TableConnector stateDbConnector, SwitchOrch *switchOrch, PortsOrch *portOrch, VRFOrch *vrfOrch) :
+        Orch(confDbConnector.first, confDbConnector.second),
+        m_stateDbTwampTable(stateDbConnector.first, stateDbConnector.second),
+        m_switchOrch(switchOrch),
+        m_portsOrch(portOrch),
+        m_vrfOrch(vrfOrch)
+{
+    /* Set entries count to 0 */
+    m_maxTwampSessionCount = m_twampSessionCount = 0;
+
+    /* Get the Maximum supported TWAMP sessions */
+    SWSS_LOG_INFO("Get the Maximum supported TWAMP sessions");
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_MAX_TWAMP_SESSION;
+    sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_NOTICE("Twamp session resource availability is not supported. Skipping ...");
+        return;
+    }
+    else
+    {
+        m_maxTwampSessionCount = attr.value.u32;
+    }
+
+    /* Set MAX entries to state DB */
+    if (m_maxTwampSessionCount)
+    {
+        vector<FieldValueTuple> fvTuple;
+        fvTuple.emplace_back("MAX_TWAMP_SESSION_COUNT", to_string(m_maxTwampSessionCount));
+        m_switchOrch->set_switch_capability(fvTuple);
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("Twamp session resource availability is not supported. Skipping ...");
+        return;
+    }
+
+    /* Add TWAMP session event notification support */
+    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
+    m_twampNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
+    auto twampNotifier = new Notifier(m_twampNotificationConsumer, this, "TWAMP_NOTIFICATIONS");
+    Orch::addExecutor(twampNotifier);
+    register_event_notif = false;
+
+    /* Initialize DB connectors */
+    m_asicDb = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
+    m_countersDb = shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
+
+    /* Initialize VIDTORID table */
+    m_vidToRidTable = unique_ptr<Table>(new Table(m_asicDb.get(), "VIDTORID"));
+
+    /* Initialize counter tables */
+    m_counterTwampSessionNameMapTable = unique_ptr<Table>(new Table(m_countersDb.get(), COUNTERS_TWAMP_SESSION_NAME_MAP));
+    m_countersTable = unique_ptr<Table>(new Table(m_countersDb.get(), COUNTERS_TABLE));
+}
+
+bool TwampOrch::isSessionExists(const string& name)
+{
+    SWSS_LOG_ENTER();
+
+    return m_twampEntries.find(name) != m_twampEntries.end();
+}
+
+bool TwampOrch::getSessionName(const sai_object_id_t oid, string& name)
+{
+    SWSS_LOG_ENTER();
+
+    for (const auto& it: m_twampEntries)
+    {
+        if (it.second.session_id == oid)
+        {
+            name = it.first;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool TwampOrch::validateUdpPort(uint16_t udp_port)
+{
+    if (udp_port == 862)
+    {
+        return true;
+    }
+    if (udp_port == 863)
+    {
+        return true;
+    }
+    if (udp_port >= 1025)
+    {
+        return true;
+    }
+    return false;
+}
+
+void TwampOrch::increaseTwampSessionCount(void)
+{
+    m_twampSessionCount++;
+}
+
+void TwampOrch::decreaseTwampSessionCount(void)
+{
+    m_twampSessionCount--;
+}
+
+bool TwampOrch::checkTwampSessionCount(void)
+{
+    return m_twampSessionCount < m_maxTwampSessionCount;
+}
+
+void TwampOrch::setSessionStatus(const string& name, const string& status)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fvVector;
+    fvVector.emplace_back(TWAMP_SESSION_STATUS, status);
+    m_stateDbTwampTable.set(name, fvVector);
+}
+
+bool TwampOrch::getSessionStatus(const string &name, string& status)
+{
+    SWSS_LOG_ENTER();
+
+    if (m_stateDbTwampTable.hget(name, TWAMP_SESSION_STATUS, status))
+    {
+        return true;
+    }
+    return false;
+}
+
+void TwampOrch::removeSessionStatus(const string& name)
+{
+    SWSS_LOG_ENTER();
+
+    m_stateDbTwampTable.del(name);
+}
+
+void TwampOrch::removeSessionCounter(const sai_object_id_t session_id)
+{
+    SWSS_LOG_ENTER();
+
+    string key_pattern = "COUNTERS:" + sai_serialize_object_id(session_id) + "*";
+    auto keys = m_countersDb->keys(key_pattern);
+    for (auto& k : keys)
+    {
+        m_countersDb->del(k);
+    }
+}
+
+void TwampOrch::initSessionStats(const string& name)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_twampStatistics.find(name);
+    if (it == m_twampStatistics.end())
+    {
+        SWSS_LOG_ERROR("Failed to init non-existent twamp session %s stat info", name.c_str());
+        return;
+    }
+
+    TwampStats& total_stats = it->second;
+
+    total_stats.rx_packets        = 0;
+    total_stats.rx_bytes          = 0;
+    total_stats.tx_packets        = 0;
+    total_stats.tx_bytes          = 0;
+    total_stats.drop_packets      = 0;
+    total_stats.max_latency       = 0;
+    total_stats.min_latency       = 0;
+    total_stats.avg_latency       = 0;
+    total_stats.max_jitter        = 0;
+    total_stats.min_jitter        = 0;
+    total_stats.avg_jitter        = 0;
+    total_stats.avg_latency_total = 0;
+    total_stats.avg_jitter_total  = 0;
+}
+
+bool TwampOrch::registerTwampEventNotification(void)
+{
+    sai_attribute_t attr;
+    sai_status_t status;
+    sai_attr_capability_t capability;
+
+    status = sai_query_attribute_capability(gSwitchId, SAI_OBJECT_TYPE_SWITCH,
+                                            SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY,
+                                            &capability);
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_NOTICE("Unable to query the TWAMP event notification capability");
+        return false;
+    }
+
+    if (!capability.set_implemented)
+    {
+        SWSS_LOG_NOTICE("TWAMP register event notification not supported");
+        return false;
+    }
+
+    attr.id = SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void *)on_twamp_session_event;
+
+    status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to register TWAMP notification handler");
+        return false;
+    }
+
+    return true;
+}
+
+bool TwampOrch::activateSession(const string& name, TwampEntry& entry)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status;
+    sai_attribute_t attr;
+    vector<sai_attribute_t> attrs;
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_TWAMP_MODE;
+    attr.value.s32 = entry.mode;
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_SESSION_ROLE;
+    attr.value.s32 = entry.role;
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_HW_LOOKUP_VALID;
+    attr.value.booldata = entry.hw_lookup;
+    attrs.emplace_back(attr);
+
+    if (entry.vrf_id)
+    {
+        attr.id = SAI_TWAMP_SESSION_ATTR_VIRTUAL_ROUTER;
+        attr.value.oid = entry.vrf_id;
+        attrs.emplace_back(attr);
+    }
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_SRC_IP;
+    copy(attr.value.ipaddr, entry.src_ip);
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_DST_IP;
+    copy(attr.value.ipaddr, entry.dst_ip);
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_UDP_SRC_PORT;
+    attr.value.u32 = entry.src_udp_port;
+    attrs.emplace_back(attr);
+
+    attr.id = SAI_TWAMP_SESSION_ATTR_UDP_DST_PORT;
+    attr.value.u32 = entry.dst_udp_port;
+    attrs.emplace_back(attr);
+
+    if (entry.role == SAI_TWAMP_SESSION_ROLE_SENDER)
+    {
+        if (entry.tx_mode == TWAMP_SESSION_TX_MODE_PACKET_NUM)
+        {
+            attr.id = SAI_TWAMP_SESSION_ATTR_TWAMP_PKT_TX_MODE;
+            attr.value.s32 = SAI_TWAMP_PKT_TX_MODE_PACKET_COUNT;
+            attrs.emplace_back(attr);
+
+            attr.id = SAI_TWAMP_SESSION_ATTR_TX_PKT_CNT;
+            attr.value.u32 = entry.packet_count;
+            attrs.emplace_back(attr);
+        }
+        else if (entry.tx_mode == TWAMP_SESSION_TX_MODE_CONTINUOUS)
+        {
+            if (entry.monitor_time)
+            {
+                attr.id = SAI_TWAMP_SESSION_ATTR_TWAMP_PKT_TX_MODE;
+                attr.value.u32 = SAI_TWAMP_PKT_TX_MODE_PERIOD;
+                attrs.emplace_back(attr);
+
+                attr.id = SAI_TWAMP_SESSION_ATTR_TX_PKT_PERIOD;
+                attr.value.u32 = entry.monitor_time;
+                attrs.emplace_back(attr);
+            }
+            else
+            {
+                attr.id = SAI_TWAMP_SESSION_ATTR_TWAMP_PKT_TX_MODE;
+                attr.value.u32 = SAI_TWAMP_PKT_TX_MODE_CONTINUOUS;
+                attrs.emplace_back(attr);
+            }
+        }
+
+        attr.id = SAI_TWAMP_SESSION_ATTR_TX_INTERVAL;
+        attr.value.u32 = entry.tx_interval;
+        attrs.emplace_back(attr);
+
+        attr.id = SAI_TWAMP_SESSION_ATTR_TIMEOUT;
+        attr.value.u32 = entry.timeout;
+        attrs.emplace_back(attr);
+
+        attr.id = SAI_TWAMP_SESSION_ATTR_STATISTICS_INTERVAL;
+        attr.value.u32 = entry.statistics_interval;
+        attrs.emplace_back(attr);
+
+        attr.id = SAI_TWAMP_SESSION_ATTR_SESSION_ENABLE_TRANSMIT;
+        attr.value.booldata = entry.admin_state;
+        attrs.emplace_back(attr);
+    }
+
+    setSessionStatus(name, TWAMP_SESSION_STATUS_INACTIVE);
+
+    status = sai_twamp_api->create_twamp_session(&entry.session_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to create twamp session %s, status %d", name.c_str(), status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_TWAMP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    /* increase VRF reference count */
+    m_vrfOrch->increaseVrfRefCount(entry.vrf_id);
+    gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_TWAMP_ENTRY);
+
+    increaseTwampSessionCount();
+
+    if (entry.role == SAI_TWAMP_SESSION_ROLE_REFLECTOR)
+    {
+        setSessionStatus(name, TWAMP_SESSION_STATUS_ACTIVE);
+    }
+
+    return true;
+}
+
+bool TwampOrch::deactivateSession(const string& name, TwampEntry& entry)
+{
+    SWSS_LOG_ENTER();
+    sai_status_t status;
+
+    status = sai_twamp_api->remove_twamp_session(entry.session_id);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to remove twamp session %s, status %d", name.c_str(), status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_TWAMP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    /* decrease VRF reference count */
+    m_vrfOrch->decreaseVrfRefCount(entry.vrf_id);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_TWAMP_ENTRY);
+
+    decreaseTwampSessionCount();
+
+    setSessionStatus(name, TWAMP_SESSION_STATUS_INACTIVE);
+
+    return true;
+}
+
+bool TwampOrch::setSessionTransmitEn(TwampEntry& entry, string admin_state)
+{
+    SWSS_LOG_ENTER();
+
+    if (entry.role != SAI_TWAMP_SESSION_ROLE_SENDER)
+    {
+        return false;
+    }
+
+    auto found = session_admin_state_map.find(admin_state);
+    if (found == session_admin_state_map.end())
+    {
+        SWSS_LOG_ERROR("Incorrect transmit value: %s", admin_state.c_str());
+        return false;
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_TWAMP_SESSION_ATTR_SESSION_ENABLE_TRANSMIT;
+    attr.value.booldata = found->second;
+    sai_status_t status = sai_twamp_api->set_twamp_session_attribute(entry.session_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set twamp session %" PRIx64 " %s transmit, status %d",
+                        entry.session_id, admin_state.c_str(), status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_TWAMP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
+
+    return true;
+}
+
+task_process_status TwampOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    if (!register_event_notif)
+    {
+        if (!registerTwampEventNotification())
+        {
+            SWSS_LOG_ERROR("TWAMP session for %s cannot be created", key.c_str());
+            return task_process_status::task_failed;
+        }
+        register_event_notif = true;
+    }
+
+    if (!checkTwampSessionCount())
+    {
+        SWSS_LOG_NOTICE("Failed to create twamp session %s: resources are not available", key.c_str());
+        return task_process_status::task_failed;
+    }
+
+    TwampEntry entry;
+    for (auto i : data)
+    {
+        try {
+            string attr_name  = to_upper(fvField(i));
+            string attr_value = fvValue(i);
+
+            if (attr_name == TWAMP_SESSION_MODE)
+            {
+                string value = to_upper(attr_value);
+                if (twamp_mode_map.find(value) == twamp_mode_map.end())
+                {
+                    SWSS_LOG_ERROR("Failed to parse valid mode %s", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.mode = twamp_mode_map[value];
+            }
+            else if (attr_name == TWAMP_SESSION_ROLE)
+            {
+                string value = to_upper(attr_value);
+                if (twamp_role_map.find(value) == twamp_role_map.end())
+                {
+                    SWSS_LOG_ERROR("Failed to parse valid role %s", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.role = twamp_role_map[value];
+            }
+            else if (attr_name == TWAMP_SESSION_SRC_IP)
+            {
+                entry.src_ip = attr_value;
+            }
+            else if (attr_name == TWAMP_SESSION_DST_IP)
+            {
+                entry.dst_ip = attr_value;
+            }
+            else if (attr_name == TWAMP_SESSION_SRC_UDP_PORT)
+            {
+                uint16_t value = to_uint<uint16_t>(attr_value);
+                if (!validateUdpPort(value))
+                {
+                    SWSS_LOG_ERROR("Failed to parse valid souce udp port %d", value);
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.src_udp_port = value;
+            }
+            else if (attr_name == TWAMP_SESSION_DST_UDP_PORT)
+            {
+                uint16_t value = to_uint<uint16_t>(attr_value);
+                if (!validateUdpPort(value))
+                {
+                    SWSS_LOG_ERROR("Failed to parse valid destination udp port %d", value);
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.dst_udp_port = to_uint<uint16_t>(attr_value);
+            }
+            else if (attr_name == TWAMP_SESSION_VRF_NAME)
+            {
+                if (attr_value == "default")
+                {
+                    entry.vrf_id = gVirtualRouterId;
+                }
+                else
+                {
+                    if (!m_vrfOrch->isVRFexists(attr_value))
+                    {
+                        SWSS_LOG_WARN("Vrf '%s' hasn't been created yet", attr_value.c_str());
+                        return task_process_status::task_invalid_entry;
+                    }
+                    entry.vrf_id = m_vrfOrch->getVRFid(attr_value);
+                }
+            }
+            else if (attr_name == TWAMP_SESSION_DSCP)
+            {
+                entry.dscp = to_uint<uint8_t>(attr_value, TWAMP_SESSION_DSCP_MIN, TWAMP_SESSION_DSCP_MAX);
+            }
+            else if (attr_name == TWAMP_SESSION_TTL)
+            {
+                entry.ttl = to_uint<uint8_t>(attr_value);
+            }
+            else if (attr_name == TWAMP_SESSION_PACKET_TIMESTAMP_FORMAT)
+            {
+                string value = to_upper(attr_value);
+                if (timestamp_format_map.find(value) == timestamp_format_map.end())
+                {
+                    SWSS_LOG_ERROR("Failed to parse timestamp format value: %s", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.timestamp_format = timestamp_format_map[value];
+            }
+            else if (attr_name == TWAMP_SESSION_PACKET_PADDING_SIZE)
+            {
+                entry.padding_size = to_uint<uint16_t>(attr_value);
+            }
+            else if (attr_name == TWAMP_SESSION_TX_PACKET_COUNT)
+            {
+                if (entry.tx_mode == TWAMP_SESSION_TX_MODE_CONTINUOUS)
+                {
+                    SWSS_LOG_ERROR("Configured packet count %s is conflict with monitor time", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+
+                entry.packet_count = to_uint<uint32_t>(attr_value);
+                entry.tx_mode = TWAMP_SESSION_TX_MODE_PACKET_NUM;
+            }
+            else if (attr_name == TWAMP_SESSION_TX_MONITOR_TIME)
+            {
+                if (entry.tx_mode == TWAMP_SESSION_TX_MODE_PACKET_NUM)
+                {
+                    SWSS_LOG_ERROR("Configured monitor time %s is conflict with packet count", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+
+                entry.monitor_time = to_uint<uint32_t>(attr_value);
+                entry.tx_mode = TWAMP_SESSION_TX_MODE_CONTINUOUS;
+            }
+            else if (attr_name == TWAMP_SESSION_TX_INTERVAL)
+            {
+                entry.tx_interval = to_uint<uint32_t>(attr_value);
+            }
+            else if (attr_name == TWAMP_SESSION_STATISTICS_INTERVAL)
+            {
+                entry.statistics_interval = to_uint<uint32_t>(attr_value);
+            }
+            else if (attr_name == TWAMP_SESSION_TIMEOUT)
+            {
+                entry.timeout = to_uint<uint8_t>(attr_value, TWAMP_SESSION_TIMEOUT_MIN, TWAMP_SESSION_TIMEOUT_MAX);
+            }
+            else if (attr_name == TWAMP_SESSION_ADMIN_STATE)
+            {
+                string value = to_upper(attr_value);
+                if (session_admin_state_map.find(value) == session_admin_state_map.end())
+                {
+                    SWSS_LOG_ERROR("Failed to parse transmit mode value: %s", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.admin_state = session_admin_state_map[value];
+            }
+            else if (attr_name == TWAMP_SESSION_HW_LOOKUP)
+            {
+                string value = to_upper(attr_value);
+                if (hw_lookup_map.find(value) == hw_lookup_map.end())
+                {
+                    SWSS_LOG_ERROR("Failed to parse hw lookup value: %s", attr_value.c_str());
+                    return task_process_status::task_invalid_entry;
+                }
+                entry.hw_lookup = hw_lookup_map[value];
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to parse session %s configuration. Unknown attribute %s", key.c_str(), attr_name.c_str());
+                return task_process_status::task_invalid_entry;
+            }
+        }
+        catch (const exception& e)
+        {
+            SWSS_LOG_ERROR("Failed to parse session %s attribute %s error: %s.", key.c_str(), fvField(i).c_str(), e.what());
+            return task_process_status::task_invalid_entry;
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Failed to parse session %s attribute %s. Unknown error has been occurred", key.c_str(), fvField(i).c_str());
+            return task_process_status::task_failed;
+        }
+    }
+
+    m_twampEntries.emplace(key, entry);
+
+    if (entry.role == SAI_TWAMP_SESSION_ROLE_SENDER)
+    {
+        TwampStats hw_stats;
+        m_twampStatistics.emplace(key, hw_stats);
+        initSessionStats(key);
+    }
+
+    auto &session = m_twampEntries.find(key)->second;
+    if (!activateSession(key, session))
+    {
+        SWSS_LOG_ERROR("Failed to create twamp session %s", key.c_str());
+        return task_process_status::task_failed;
+    }
+
+    return task_process_status::task_success;
+}
+
+task_process_status TwampOrch::updateEntry(const string& key, const vector<FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_twampEntries.find(key);
+    if (it == m_twampEntries.end())
+    {
+        SWSS_LOG_NOTICE("Failed to set twamp session, session %s not exists", key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+    TwampEntry& entry = it->second;
+
+    for (auto i : data)
+    {
+        try {
+            const auto &attr_field = to_upper(fvField(i));
+            const auto &attr_value = fvValue(i);
+
+            if (attr_field == TWAMP_SESSION_ADMIN_STATE)
+            {
+                string value = to_upper(attr_value);
+                if (setSessionTransmitEn(entry, value))
+                {
+                    entry.admin_state = session_admin_state_map[value];
+                    if (entry.admin_state)
+                    {
+                        string running_status;
+                        getSessionStatus(key, running_status);
+                        if (running_status == TWAMP_SESSION_STATUS_INACTIVE)
+                        {
+                            removeSessionCounter(entry.session_id);
+                            initSessionStats(key);
+                        }
+                        setSessionStatus(key, TWAMP_SESSION_STATUS_ACTIVE);
+                        SWSS_LOG_NOTICE("Activated twamp session %s", key.c_str());
+                    }
+                    else
+                    {
+                        setSessionStatus(key, TWAMP_SESSION_STATUS_INACTIVE);
+                        SWSS_LOG_NOTICE("Deactivated twamp session %s", key.c_str());
+                    }
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to set twamp session %s transmit %s", key.c_str(), attr_value.c_str());
+                }
+            }
+            else
+            {
+                SWSS_LOG_DEBUG("Ignore to parse session %s configuration attribute %s", key.c_str(), fvField(i).c_str());
+            }
+        }
+        catch (const exception& e)
+        {
+            SWSS_LOG_ERROR("Failed to parse session %s attribute %s error: %s.", key.c_str(), fvField(i).c_str(), e.what());
+            return task_process_status::task_invalid_entry;
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Failed to parse session %s attribute %s. Unknown error has been occurred", key.c_str(), fvField(i).c_str());
+            return task_process_status::task_failed;
+        }
+    }
+
+    return task_process_status::task_success;
+}
+
+task_process_status TwampOrch::deleteEntry(const string& key)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_twampEntries.find(key);
+    if (it == m_twampEntries.end())
+    {
+        SWSS_LOG_ERROR("Failed to remove non-existent twamp session %s", key.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
+    TwampEntry& entry = it->second;
+
+    if (!deactivateSession(key, entry))
+    {
+        SWSS_LOG_ERROR("Failed to remove twamp session %s", key.c_str());
+        return task_process_status::task_failed;
+    }
+
+    /* remove TWAMP session in STATE_DB */
+    removeSessionStatus(key);
+
+    /* remove TWAMP session maps in COUNTERS_DB */
+    m_counterTwampSessionNameMapTable->hdel("", key);
+
+    /* remove TWAMP session in COUNTER_DB */
+    removeSessionCounter(entry.session_id);
+
+    /* remove soft table in orchagent */
+    m_twampEntries.erase(key);
+    m_twampStatistics.erase(key);
+
+    SWSS_LOG_NOTICE("Removed twamp session %s", key.c_str());
+
+    return task_process_status::task_success;
+}
+
+void TwampOrch::doTask(Consumer& consumer)
+{
+    SWSS_LOG_ENTER();
+
+    if (!m_portsOrch->allPortsReady())
+    {
+        return;
+    }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        auto data = kfvFieldsValues(t);
+        task_process_status task_status = task_process_status::task_failed;
+
+        if (op == SET_COMMAND)
+        {
+            if (!isSessionExists(key))
+            {
+                task_status = createEntry(key, data);
+            }
+            else
+            {
+                task_status = updateEntry(key, data);
+            }
+        }
+        else if (op == DEL_COMMAND)
+        {
+            task_status = deleteEntry(key);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        }
+
+        /* Specifically retry the task when asked */
+        if (task_status == task_process_status::task_need_retry)
+        {
+            it++;
+        }
+        else
+        {
+            it = consumer.m_toSync.erase(it);
+        }
+    }
+}
+
+bool TwampOrch::addCounterNameMap(const string& name, const sai_object_id_t session_id)
+{
+    SWSS_LOG_ENTER();
+
+    string value;
+    const auto id = sai_serialize_object_id(session_id);
+
+    if (m_vidToRidTable->hget("", id, value))
+    {
+        vector<FieldValueTuple> fields;
+        fields.emplace_back(name, id);
+        m_counterTwampSessionNameMapTable->set("", fields);
+
+        return true;
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("TWAMP session counter %s already exists.", name.c_str());
+        return true;
+    }
+
+    return false;
+}
+
+void TwampOrch::saveSessionStatsLatest(const sai_object_id_t session_id, const uint32_t index, const vector<uint64_t>& stats)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> values;
+
+    for (const auto& it: twamp_session_stat_ids)
+    {
+        values.emplace_back(sai_serialize_twamp_session_stat(it), to_string(stats[it]));
+    }
+
+    m_countersTable->set(sai_serialize_object_id(session_id) + ":INDEX:" + to_string(index), values);
+
+    return;
+}
+
+void TwampOrch::calculateCounters(const string& name, const uint32_t index, const vector<uint64_t>& stats)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = m_twampStatistics.find(name);
+    if (it == m_twampStatistics.end())
+    {
+        SWSS_LOG_ERROR("Failed to caculate non-existent twamp session %s", name.c_str());
+        return;
+    }
+
+    TwampStats& total_stats = it->second;
+    /* packets */
+    total_stats.rx_packets   += stats[SAI_TWAMP_SESSION_STAT_RX_PACKETS];
+    total_stats.rx_bytes     += stats[SAI_TWAMP_SESSION_STAT_RX_BYTE];
+    total_stats.tx_packets   += stats[SAI_TWAMP_SESSION_STAT_TX_PACKETS];
+    total_stats.tx_bytes     += stats[SAI_TWAMP_SESSION_STAT_TX_BYTE];
+    total_stats.drop_packets += stats[SAI_TWAMP_SESSION_STAT_DROP_PACKETS];
+
+    /* latency */
+    total_stats.max_latency = (stats[SAI_TWAMP_SESSION_STAT_MAX_LATENCY] > total_stats.max_latency) ?
+                               stats[SAI_TWAMP_SESSION_STAT_MAX_LATENCY] : total_stats.max_latency;
+    total_stats.min_latency = (index == 1) ? stats[SAI_TWAMP_SESSION_STAT_MIN_LATENCY] :
+                               ((stats[SAI_TWAMP_SESSION_STAT_MIN_LATENCY] < total_stats.min_latency) ?
+                                 stats[SAI_TWAMP_SESSION_STAT_MIN_LATENCY] : total_stats.min_latency);
+    total_stats.avg_latency_total += stats[SAI_TWAMP_SESSION_STAT_AVG_LATENCY];
+    total_stats.avg_latency = total_stats.avg_latency_total / index;
+
+    /* jitter */
+    total_stats.max_jitter = (stats[SAI_TWAMP_SESSION_STAT_MAX_JITTER] > total_stats.max_jitter) ?
+                              stats[SAI_TWAMP_SESSION_STAT_MAX_JITTER] : total_stats.max_jitter;
+    total_stats.min_jitter = (index == 1) ? stats[SAI_TWAMP_SESSION_STAT_MIN_JITTER] :
+                              ((stats[SAI_TWAMP_SESSION_STAT_MIN_JITTER] < total_stats.min_jitter) ?
+                                stats[SAI_TWAMP_SESSION_STAT_MIN_JITTER] : total_stats.min_jitter);
+    total_stats.avg_jitter_total += stats[SAI_TWAMP_SESSION_STAT_AVG_JITTER];
+    total_stats.avg_jitter = total_stats.avg_jitter_total / index;
+}
+
+void TwampOrch::saveCountersTotal(const string& name, const sai_object_id_t session_id)
+{
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> values;
+
+    auto it = m_twampStatistics.find(name);
+    if (it == m_twampStatistics.end())
+    {
+        SWSS_LOG_ERROR("Failed to caculate non-existent twamp session %s",
+                name.c_str());
+        return;
+    }
+
+    TwampStats& total_stats = it->second;
+
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_RX_PACKETS), to_string(total_stats.rx_packets));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_RX_BYTE), to_string(total_stats.rx_bytes));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_TX_PACKETS), to_string(total_stats.tx_packets));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_TX_BYTE), to_string(total_stats.tx_bytes));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_DROP_PACKETS), to_string(total_stats.drop_packets));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_MAX_LATENCY), to_string(total_stats.max_latency));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_MIN_LATENCY), to_string(total_stats.min_latency));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_AVG_LATENCY), to_string(total_stats.avg_latency));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_MAX_JITTER), to_string(total_stats.max_jitter));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_MIN_JITTER), to_string(total_stats.min_jitter));
+    values.emplace_back(sai_serialize_twamp_session_stat(SAI_TWAMP_SESSION_STAT_AVG_JITTER), to_string(total_stats.avg_jitter));
+
+    m_countersTable->set(sai_serialize_object_id(session_id), values);
+}
+
+void TwampOrch::doTask(NotificationConsumer& consumer)
+{
+    SWSS_LOG_ENTER();
+
+    if (!m_portsOrch->allPortsReady())
+    {
+        return;
+    }
+
+    std::string op;
+    std::string data;
+    std::vector<swss::FieldValueTuple> values;
+
+    consumer.pop(op, data, values);
+
+    if (&consumer != m_twampNotificationConsumer)
+    {
+        return;
+    }
+
+    if (op == "twamp_session_event")
+    {
+        uint32_t count = 0;
+        sai_twamp_session_event_notification_data_t *twamp_session = nullptr;
+
+        sai_deserialize_twamp_session_event_ntf(data, count, &twamp_session);
+
+        for (uint32_t i = 0; i < count; i++)
+        {
+            string name;
+            sai_object_id_t session_id = twamp_session[i].twamp_session_id;
+            sai_twamp_session_state_t session_state = twamp_session[i].session_state;
+            uint32_t stats_index = twamp_session[i].session_stats.index;
+
+            if (!getSessionName(session_id, name))
+            {
+                continue;
+            }
+
+            /* update state db */
+            if (session_state == SAI_TWAMP_SESSION_STATE_ACTIVE)
+            {
+                setSessionStatus(name, TWAMP_SESSION_STATUS_ACTIVE);
+            }
+            else
+            {
+                setSessionStatus(name, TWAMP_SESSION_STATUS_INACTIVE);
+            }
+
+            /* save counter db */
+            if (twamp_session[i].session_stats.number_of_counters)
+            {
+                if (0 == stats_index)
+                {
+                    continue;
+                }
+                else if (1 == stats_index)
+                {
+                    addCounterNameMap(name, session_id);
+                }
+
+                vector<uint64_t> hw_stats;
+                hw_stats.resize(twamp_session_stat_ids.size());
+                for (uint32_t j = 0; j < twamp_session[i].session_stats.number_of_counters; j++)
+                {
+                    uint32_t counters_id = twamp_session[i].session_stats.counters_ids[j];
+                    auto it = find(twamp_session_stat_ids.begin(), twamp_session_stat_ids.end(), counters_id);
+                    if (it != twamp_session_stat_ids.end())
+                    {
+                        hw_stats[counters_id] = twamp_session[i].session_stats.counters[j];
+                    }
+                }
+
+                saveSessionStatsLatest(session_id, stats_index, hw_stats);
+                calculateCounters(name, stats_index, hw_stats);
+                saveCountersTotal(name, session_id);
+            }
+        }
+
+        sai_deserialize_free_twamp_session_event_ntf(count, twamp_session);
+    }
+}

--- a/orchagent/twamporch.h
+++ b/orchagent/twamporch.h
@@ -1,0 +1,136 @@
+#ifndef SWSS_TWAMPORCH_H
+#define SWSS_TWAMPORCH_H
+
+#include "orch.h"
+#include "observer.h"
+#include "switchorch.h"
+#include "portsorch.h"
+#include "vrforch.h"
+#include "ipaddress.h"
+#include "table.h"
+#include <map>
+
+struct TwampStats
+{
+    uint64_t rx_packets;
+    uint64_t rx_bytes;
+    uint64_t tx_packets;
+    uint64_t tx_bytes;
+    uint64_t drop_packets;
+    uint64_t max_latency;
+    uint64_t min_latency;
+    uint64_t avg_latency;
+    uint64_t max_jitter;
+    uint64_t min_jitter;
+    uint64_t avg_jitter;
+    uint64_t avg_latency_total;
+    uint64_t avg_jitter_total;
+};
+
+struct TwampEntry
+{
+    uint8_t  mode;         /* twamp mode: full, light */
+    uint8_t  role;         /* sender, reflector */
+    bool     admin_state;  /* test packet state. enabled, disabled */
+    bool     hw_lookup;
+
+    sai_object_id_t  vrf_id;
+    IpAddress src_ip;
+    IpAddress dst_ip;
+    uint16_t  src_udp_port;
+    uint16_t  dst_udp_port;
+    uint16_t  padding_size;
+    uint8_t   dscp;
+    uint8_t   ttl;
+    uint8_t   timestamp_format;
+
+    /* sender attr */
+    string    tx_mode;
+    uint32_t  packet_count;
+    uint32_t  monitor_time;         /* second */
+    uint32_t  tx_interval;          /* millisecond */
+    uint32_t  statistics_interval;  /* millisecond */
+    uint8_t   timeout;              /* second */
+
+    sai_object_id_t session_id;
+
+    TwampEntry()
+    {
+        session_id = 0;
+        admin_state = false;
+        hw_lookup = true;
+        vrf_id = 0;
+        packet_count = 0;
+        monitor_time = 0;
+        tx_interval = 0;
+        statistics_interval = 0;
+        timeout = 0;
+    };
+};
+
+typedef map<string, TwampEntry> TwampEntryTable;
+typedef map<string, TwampStats> TwampStatsTable;
+
+class TwampOrch : public Orch
+{
+public:
+    TwampOrch(TableConnector confDbConnector, TableConnector stateDbConnector,
+              SwitchOrch *switchOrch, PortsOrch *portOrch, VRFOrch *vrfOrch);
+
+    ~TwampOrch()
+    {
+        // do nothing
+    }
+
+    bool isSessionExists(const string&);
+    bool getSessionName(const sai_object_id_t oid, string& name);
+
+private:
+    SwitchOrch *m_switchOrch;
+    PortsOrch  *m_portsOrch;
+    VRFOrch    *m_vrfOrch;
+    NotificationConsumer* m_twampNotificationConsumer;
+    bool register_event_notif;
+
+    unsigned int m_twampSessionCount;
+    unsigned int m_maxTwampSessionCount;
+
+    TwampEntryTable m_twampEntries;
+    TwampStatsTable m_twampStatistics;
+
+    shared_ptr<DBConnector> m_asicDb;
+    shared_ptr<DBConnector> m_countersDb;
+    unique_ptr<Table> m_counterTwampSessionNameMapTable;
+    unique_ptr<Table> m_countersTable;
+    unique_ptr<Table> m_vidToRidTable;
+    Table m_stateDbTwampTable;
+
+    bool validateUdpPort(uint16_t udp_port);
+    void increaseTwampSessionCount(void);
+    void decreaseTwampSessionCount(void);
+    bool checkTwampSessionCount(void);
+
+    void setSessionStatus(const string&, const string&);
+    bool getSessionStatus(const string&, string&);
+    void removeSessionStatus(const string&);
+    void removeSessionCounter(const sai_object_id_t);
+    void initSessionStats(const string&);
+
+    bool registerTwampEventNotification(void);
+    bool activateSession(const string&, TwampEntry&);
+    bool deactivateSession(const string&, TwampEntry&);
+    bool setSessionTransmitEn(TwampEntry&, string test_start);
+
+    task_process_status createEntry(const string&, const vector<FieldValueTuple>&);
+    task_process_status updateEntry(const string&, const vector<FieldValueTuple>&);
+    task_process_status deleteEntry(const string&);
+    void doTask(Consumer& consumer);
+
+    bool addCounterNameMap(const string&, const sai_object_id_t session_id);
+    void saveSessionStatsLatest(const sai_object_id_t session_id, const uint32_t index, const vector<uint64_t>& stats);
+    void calculateCounters(const string&, const uint32_t index, const vector<uint64_t>& stats);
+    void saveCountersTotal(const string&, const sai_object_id_t session_id);
+    void doTask(NotificationConsumer& consumer);
+};
+
+#endif /* SWSS_TWAMPORCH_H */

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ from dvslib import dvs_mirror
 from dvslib import dvs_policer
 from dvslib import dvs_hash
 from dvslib import dvs_switch
+from dvslib import dvs_twamp
 
 from buffer_model import enable_dynamic_buffer
 
@@ -1991,6 +1992,14 @@ def dvs_hash_manager(request, dvs):
 @pytest.fixture(scope="class")
 def dvs_switch_manager(request, dvs):
     request.cls.dvs_switch = dvs_switch.DVSSwitch(dvs.get_asic_db())
+
+@pytest.fixture(scope="class")
+def dvs_twamp_manager(request, dvs):
+    request.cls.dvs_twamp = dvs_twamp.DVSTwamp(dvs.get_asic_db(),
+                                               dvs.get_config_db(),
+                                               dvs.get_state_db(),
+                                               dvs.get_counters_db(),
+                                               dvs.get_app_db())
 
 ##################### DPB fixtures ###########################################
 def create_dpb_config_file(dvs):

--- a/tests/dvslib/dvs_twamp.py
+++ b/tests/dvslib/dvs_twamp.py
@@ -1,0 +1,98 @@
+"""Utilities for interacting with TWAMP Light objects when writing VS tests."""
+
+class DVSTwamp(object):
+    def __init__(self, adb, cdb, sdb, cntrdb, appdb):
+        self.asic_db = adb
+        self.config_db = cdb
+        self.state_db = sdb
+        self.counters_db = cntrdb
+        self.app_db = appdb
+
+    def create_twamp_light_session_sender_packet_count(self, name, sip, sport, dip, dport, packet_count=100, tx_interval=100, timeout=5, stats_interval=None):
+        twamp_light_entry = {"mode": "LIGHT",
+                             "role": "SENDER",
+                             "src_ip": sip,
+                             "src_udp_port": sport,
+                             "dst_ip": dip,
+                             "dst_udp_port": dport,
+                             "packet_count": packet_count,
+                             "tx_interval": tx_interval,
+                             "timeout": timeout
+                            }
+        if stats_interval:
+            twamp_light_entry["statistics_interval"] = str(stats_interval)
+        else:
+            twamp_light_entry["statistics_interval"] = str(int(packet_count) * int(tx_interval) + int(timeout)*1000)
+        self.config_db.create_entry("TWAMP_SESSION", name, twamp_light_entry)
+
+    def create_twamp_light_session_sender_continuous(self, name, sip, sport, dip, dport, monitor_time=0, tx_interval=100, timeout=5, stats_interval=None):
+        twamp_light_entry = {"mode": "LIGHT",
+                             "role": "SENDER",
+                             "src_ip": sip,
+                             "src_udp_port": sport,
+                             "dst_ip": dip,
+                             "dst_udp_port": dport,
+                             "monitor_time": monitor_time,
+                             "tx_interval": tx_interval,
+                             "timeout": timeout
+                            }
+        if stats_interval:
+            twamp_light_entry["statistics_interval"] = str(stats_interval)
+        else:
+            twamp_light_entry["statistics_interval"] = str(int(monitor_time)*1000)
+        self.config_db.create_entry("TWAMP_SESSION", name, twamp_light_entry)
+
+    def create_twamp_light_session_reflector(self, name, sip, sport, dip, dport):
+        twamp_light_entry = {"mode": "LIGHT",
+                             "role": "REFLECTOR",
+                             "src_ip": sip,
+                             "src_udp_port": sport,
+                             "dst_ip": dip,
+                             "dst_udp_port": dport
+                            }
+        self.config_db.create_entry("TWAMP_SESSION", name, twamp_light_entry)
+
+    def start_twamp_light_sender(self, name):
+        twamp_light_entry = {"admin_state": "enabled"}
+        self.config_db.create_entry("TWAMP_SESSION", name, twamp_light_entry)
+
+    def stop_twamp_light_sender(self, name):
+        twamp_light_entry = {"admin_state": "disabled"}
+        self.config_db.create_entry("TWAMP_SESSION", name, twamp_light_entry)
+
+    def remove_twamp_light_session(self, name):
+        self.config_db.delete_entry("TWAMP_SESSION", name)
+
+    def get_twamp_light_session_status(self, name):
+        return self.get_twamp_light_session_state(name)["status"]
+
+    def get_twamp_light_session_state(self, name):
+        tbl = swsscommon.Table(self.sdb, "TWAMP_SESSION_TABLE")
+        (status, fvs) = tbl.get(name)
+        assert status == True
+        assert len(fvs) > 0
+        return { fv[0]: fv[1] for fv in fvs }
+
+    def verify_session_status(self, name, status="active", expected=1):
+        self.state_db.wait_for_n_keys("TWAMP_SESSION_TABLE", expected)
+        if expected:
+            self.state_db.wait_for_field_match("TWAMP_SESSION_TABLE", name, {"status": status})
+
+    def verify_no_session(self):
+        self.config_db.wait_for_n_keys("TWAMP_SESSION", 0)
+        self.state_db.wait_for_n_keys("TWAMP_SESSION_TABLE", 0)
+
+    def verify_session_asic_db(self, dvs, name, asic_table=None, expected=1):
+        session_oids = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_TWAMP_SESSION", expected)
+        session_oid = session_oids[0]
+        dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_TWAMP_SESSION", session_oid, asic_table)
+
+    def verify_session_counter_db(self, dvs, name, counter_table=None, expected=1, expected_item=1):
+        fvs = dvs.counters_db.get_entry("COUNTERS_TWAMP_SESSION_NAME_MAP", "")
+        fvs = dict(fvs)
+        total_key = self.counters_db.db_connection.keys("COUNTERS:{}".format(fvs[name]))
+        assert len(total_key) == expected, "TWAMP Light counter entries are not available in counter db"
+        dvs.counters_db.wait_for_field_match("COUNTERS", fvs[name], counter_table)
+        item_keys = self.counters_db.db_connection.keys("COUNTERS:{}:INDEX:*".format(fvs[name]))
+        assert len(item_keys) == expected_item, "TWAMP Light counter entries are not available in counter db"
+

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -130,7 +130,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dash/dashvnetorch.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp \
-                $(top_srcdir)/orchagent/dash/pbutils.cpp
+                $(top_srcdir)/orchagent/dash/pbutils.cpp \
+                $(top_srcdir)/cfgmgr/coppmgr.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -58,6 +58,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 test_failure_handling.cpp \
                 warmrestarthelper_ut.cpp \
                 neighorch_ut.cpp \
+                twamporch_ut.cpp \
                 $(top_srcdir)/warmrestart/warmRestartHelper.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
                 $(top_srcdir)/lib/subintf.cpp \
@@ -131,7 +132,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp \
                 $(top_srcdir)/warmrestart/warmRestartAssist.cpp \
                 $(top_srcdir)/orchagent/dash/pbutils.cpp \
-                $(top_srcdir)/cfgmgr/coppmgr.cpp
+                $(top_srcdir)/cfgmgr/coppmgr.cpp \
+                $(top_srcdir)/orchagent/twamporch.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp

--- a/tests/mock_tests/copp_ut.cpp
+++ b/tests/mock_tests/copp_ut.cpp
@@ -4,34 +4,14 @@
 #include "warm_restart.h"
 #include "ut_helper.h"
 #include "coppmgr.h"
-#include "coppmgr.cpp"
 #include <fstream>
 #include <streambuf>
+
 using namespace std;
 using namespace swss;
 
-void create_init_file()
-{
-    int status = system("sudo mkdir /etc/sonic/");
-    ASSERT_EQ(status, 0);
-
-    status = system("sudo chmod 777 /etc/sonic/");
-    ASSERT_EQ(status, 0);
-    
-    status = system("sudo cp copp_cfg.json /etc/sonic/");
-    ASSERT_EQ(status, 0);
-}
-
-void cleanup()
-{
-    int status = system("sudo rm -rf /etc/sonic/");
-    ASSERT_EQ(status, 0);
-}
-
 TEST(CoppMgrTest, CoppTest)
 {
-    create_init_file();
-
     const vector<string> cfg_copp_tables = {
                 CFG_COPP_TRAP_TABLE_NAME,
                 CFG_COPP_GROUP_TABLE_NAME,
@@ -65,12 +45,10 @@ TEST(CoppMgrTest, CoppTest)
                     {"trap_ids", "ip2me"}
                 });
 
-    CoppMgr coppmgr(&cfgDb, &appDb, &stateDb, cfg_copp_tables);
+    CoppMgr coppmgr(&cfgDb, &appDb, &stateDb, cfg_copp_tables, "./copp_cfg.json");
 
     string overide_val;
     coppTable.hget("queue1_group1", "cbs",overide_val);
     EXPECT_EQ( overide_val, "6000");
-
-    cleanup();
 }
 

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -27,6 +27,7 @@
 #include "muxorch.h"
 #include "nhgorch.h"
 #include "copporch.h"
+#include "twamporch.h"
 #include "directory.h"
 
 extern int gBatchSize;
@@ -86,3 +87,4 @@ extern sai_mpls_api_t* sai_mpls_api;
 extern sai_counter_api_t* sai_counter_api;
 extern sai_samplepacket_api_t *sai_samplepacket_api;
 extern sai_fdb_api_t* sai_fdb_api;
+extern sai_twamp_api_t* sai_twamp_api;

--- a/tests/mock_tests/portal.h
+++ b/tests/mock_tests/portal.h
@@ -7,6 +7,7 @@
 #include "crmorch.h"
 #include "copporch.h"
 #include "sfloworch.h"
+#include "twamporch.h"
 #include "directory.h"
 
 #undef protected
@@ -103,6 +104,19 @@ struct Portal
         static SflowPortInfoMap getSflowPortInfoMap(SflowOrch &obj)
         {
             return obj.m_sflowPortInfoMap;
+        }
+    };
+
+    struct TwampOrchInternal
+    {
+        static bool getTwampSessionStatus(TwampOrch &obj, const string &name, string& status)
+        {
+            return obj.getSessionStatus(name, status);
+        }
+
+        static TwampStatsTable getTwampSessionStatistics(TwampOrch &obj)
+        {
+            return obj.m_twampStatistics;
         }
     };
 

--- a/tests/mock_tests/twamporch_ut.cpp
+++ b/tests/mock_tests/twamporch_ut.cpp
@@ -1,0 +1,975 @@
+#define private public // make Directory::m_values available to clean it.
+#include "directory.h"
+#undef private
+#define protected public
+#include "orch.h"
+#undef protected
+#include "ut_helper.h"
+#include "mock_orchagent_main.h"
+#include "mock_table.h"
+#include "notifier.h"
+
+extern string gMySwitchType;
+
+extern sai_object_id_t      gSwitchId;
+
+extern redisReply *mockReply;
+
+
+namespace twamporch_test
+{
+    using namespace std;
+
+    int create_twamp_session_count;
+    int set_twamp_session_count;
+    int remove_twamp_session_count;
+
+    sai_twamp_api_t ut_sai_twamp_api;
+    sai_twamp_api_t *pold_sai_twamp_api;
+    sai_switch_api_t ut_sai_switch_api;
+    sai_switch_api_t *pold_sai_switch_api;
+
+    sai_create_twamp_session_fn              old_create_twamp_session;
+    sai_remove_twamp_session_fn              old_remove_twamp_session;
+    sai_set_twamp_session_attribute_fn       old_set_twamp_session_attribute;
+
+    sai_status_t _ut_stub_sai_create_twamp_session(
+        _Out_ sai_object_id_t *twamp_session_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list)
+    {
+        *twamp_session_id = (sai_object_id_t)(0x1);
+        create_twamp_session_count++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_remove_twamp_session(
+        _In_ sai_object_id_t twamp_session_id)
+    {
+        remove_twamp_session_count++;
+        return SAI_STATUS_SUCCESS;
+    }
+
+    sai_status_t _ut_stub_sai_set_twamp_session_attribute(
+            _In_ sai_object_id_t twamp_session_id,
+            _In_ const sai_attribute_t *attr)
+    {
+        set_twamp_session_count++;
+        if (attr->id == SAI_TWAMP_SESSION_ATTR_SESSION_ENABLE_TRANSMIT)
+        {
+            return SAI_STATUS_SUCCESS;
+        }
+        return old_set_twamp_session_attribute(twamp_session_id, attr);
+    }
+
+    sai_status_t _ut_stub_sai_get_switch_attribute(
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list)
+    {
+        if (attr_count == 1)
+        {
+            if (attr_list[0].id == SAI_SWITCH_ATTR_MAX_TWAMP_SESSION)
+            {
+                attr_list[0].value.u32 = 128;
+                return SAI_STATUS_SUCCESS;
+            }
+        }
+        return pold_sai_switch_api->get_switch_attribute(switch_id, attr_count, attr_list);
+    }
+
+    sai_status_t _ut_stub_sai_set_switch_attribute(
+        _In_ sai_object_id_t switch_id,
+        _In_ const sai_attribute_t *attr)
+    {
+        if (attr[0].id == SAI_SWITCH_ATTR_TWAMP_SESSION_EVENT_NOTIFY)
+        {
+            return SAI_STATUS_SUCCESS;
+        }
+        return pold_sai_switch_api->set_switch_attribute(switch_id, attr);
+    }
+
+    void _hook_sai_twamp_api()
+    {
+        ut_sai_twamp_api = *sai_twamp_api;
+        pold_sai_twamp_api = sai_twamp_api;
+        ut_sai_twamp_api.create_twamp_session = _ut_stub_sai_create_twamp_session;
+        ut_sai_twamp_api.remove_twamp_session = _ut_stub_sai_remove_twamp_session;
+        ut_sai_twamp_api.set_twamp_session_attribute = _ut_stub_sai_set_twamp_session_attribute;
+        sai_twamp_api = &ut_sai_twamp_api;
+    }
+
+    void _unhook_sai_twamp_api()
+    {
+        sai_twamp_api = pold_sai_twamp_api;
+    }
+
+    void _hook_sai_switch_api()
+    {
+        ut_sai_switch_api = *sai_switch_api;
+        pold_sai_switch_api = sai_switch_api;
+        ut_sai_switch_api.get_switch_attribute = _ut_stub_sai_get_switch_attribute;
+        ut_sai_switch_api.set_switch_attribute = _ut_stub_sai_set_switch_attribute;
+        sai_switch_api = &ut_sai_switch_api;
+    }
+
+    void _unhook_sai_switch_api()
+    {
+        sai_switch_api = pold_sai_switch_api;
+    }
+
+    class MockTwampOrch final
+    {
+    public:
+        MockTwampOrch()
+        {
+            this->confDb = std::make_shared<DBConnector>("CONFIG_DB", 0);
+            TableConnector confDbTwampTable(this->confDb.get(), CFG_TWAMP_SESSION_TABLE_NAME);
+            TableConnector stateDbTwampTable(this->confDb.get(), STATE_TWAMP_SESSION_TABLE_NAME);
+            this->twampOrch = std::make_shared<TwampOrch>(confDbTwampTable, stateDbTwampTable, gSwitchOrch, gPortsOrch, gVrfOrch);
+        }
+        ~MockTwampOrch() = default;
+
+        void doTwampTableTask(const std::deque<KeyOpFieldsValuesTuple> &entries)
+        {
+            auto consumer = dynamic_cast<Consumer *>((this->twampOrch.get())->getExecutor(CFG_TWAMP_SESSION_TABLE_NAME));
+            consumer->addToSync(entries);
+            static_cast<Orch *>(this->twampOrch.get())->doTask(*consumer);
+        }
+
+        void doTwampNotificationTask()
+        {
+            auto exec = static_cast<Notifier *>((this->twampOrch.get())->getExecutor("TWAMP_NOTIFICATIONS"));
+            auto consumer = exec->getNotificationConsumer();
+            consumer->readData();
+            static_cast<Orch *>(this->twampOrch.get())->doTask(*consumer);
+        }
+
+        TwampOrch& get()
+        {
+            return *twampOrch;
+        }
+
+    private:
+        std::shared_ptr<DBConnector> confDb;
+        std::shared_ptr<TwampOrch> twampOrch;
+    };
+
+    class TwampOrchTest : public ::testing::Test
+    {
+    public:
+        TwampOrchTest()
+        {
+            this->initDb();
+        }
+        virtual ~TwampOrchTest() = default;
+
+        void SetUp() override
+        {
+            this->initSaiApi();
+            this->initSwitch();
+            this->initOrch();
+            this->initPorts();
+            _hook_sai_twamp_api();
+            _hook_sai_switch_api();
+        }
+
+        void TearDown() override
+        {
+            this->deinitOrch();
+            this->deinitSwitch();
+            this->deinitSaiApi();
+            _unhook_sai_twamp_api();
+            _unhook_sai_switch_api();
+        }
+
+    private:
+        void initSaiApi()
+        {
+            std::map<std::string, std::string> profileMap = {
+                { "SAI_VS_SWITCH_TYPE", "SAI_VS_SWITCH_TYPE_BCM56850" },
+                { "KV_DEVICE_MAC_ADDRESS", "20:03:04:05:06:00"        }
+            };
+            auto status = ut_helper::initSaiApi(profileMap);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void deinitSaiApi()
+        {
+            auto status = ut_helper::uninitSaiApi();
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+        }
+
+        void initSwitch()
+        {
+            sai_status_t status;
+            sai_attribute_t attr;
+
+            // Create switch
+            attr.id = SAI_SWITCH_ATTR_INIT_SWITCH;
+            attr.value.booldata = true;
+
+            status = sai_switch_api->create_switch(&gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            // Get switch source MAC address
+            attr.id = SAI_SWITCH_ATTR_SRC_MAC_ADDRESS;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gMacAddress = attr.value.mac;
+
+            // Get switch default virtual router ID
+            attr.id = SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gVirtualRouterId = attr.value.oid;
+        }
+
+        void deinitSwitch()
+        {
+            // Remove switch
+            auto status = sai_switch_api->remove_switch(gSwitchId);
+            ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+            gSwitchId = SAI_NULL_OBJECT_ID;
+            gVirtualRouterId = SAI_NULL_OBJECT_ID;
+        }
+
+        void initOrch()
+        {
+            //
+            // SwitchOrch
+            //
+            TableConnector state_switch_table(this->stateDb.get(), "SWITCH_CAPABILITY");
+            TableConnector app_switch_table(this->appDb.get(), APP_SWITCH_TABLE_NAME);
+            TableConnector conf_asic_sensors(this->configDb.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+
+            std::vector<TableConnector> switchTableList = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(this->appDb.get(), switchTableList, state_switch_table);
+            gDirectory.set(gSwitchOrch);
+            resourcesList.push_back(gSwitchOrch);
+
+            //
+            // PortsOrch
+            //
+            const int portsorch_base_pri = 40;
+
+            vector<table_name_with_pri_t> ports_tables = {
+                { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
+                { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
+                { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri     },
+                { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
+                { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri     }
+            };
+
+            ASSERT_EQ(gPortsOrch, nullptr);
+            gPortsOrch = new PortsOrch(this->appDb.get(), this->stateDb.get(), ports_tables, this->chassisAppDb.get());
+            gDirectory.set(gPortsOrch);
+            resourcesList.push_back(gPortsOrch);
+
+            //
+            // VrfOrch
+            //
+            ASSERT_EQ(gVrfOrch, nullptr);
+            gVrfOrch = new VRFOrch(this->appDb.get(), APP_VRF_TABLE_NAME, this->stateDb.get(), STATE_VRF_OBJECT_TABLE_NAME);
+            resourcesList.push_back(gVrfOrch);
+
+
+            //
+            // BufferOrch
+            //
+            std::vector<std::string> bufferTableList = {
+                APP_BUFFER_POOL_TABLE_NAME,
+                APP_BUFFER_PROFILE_TABLE_NAME,
+                APP_BUFFER_QUEUE_TABLE_NAME,
+                APP_BUFFER_PG_TABLE_NAME,
+                APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME,
+                APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME
+            };
+            gBufferOrch = new BufferOrch(this->appDb.get(), this->configDb.get(), this->stateDb.get(), bufferTableList);
+            gDirectory.set(gBufferOrch);
+            resourcesList.push_back(gBufferOrch);
+
+            //
+            // FlexCounterOrch
+            //
+            std::vector<std::string> flexCounterTableList = {
+                CFG_FLEX_COUNTER_TABLE_NAME
+            };
+
+            auto flexCounterOrch = new FlexCounterOrch(this->configDb.get(), flexCounterTableList);
+            gDirectory.set(flexCounterOrch);
+            resourcesList.push_back(flexCounterOrch);
+
+            //
+            // CrmOrch
+            //
+            ASSERT_EQ(gCrmOrch, nullptr);
+            gCrmOrch = new CrmOrch(this->configDb.get(), CFG_CRM_TABLE_NAME);
+            gDirectory.set(gCrmOrch);
+            resourcesList.push_back(gCrmOrch);
+        }
+
+        void deinitOrch()
+        {
+            std::reverse(resourcesList.begin(), resourcesList.end());
+            for (auto &it : resourcesList)
+            {
+                delete it;
+            }
+
+            gSwitchOrch = nullptr;
+            gPortsOrch = nullptr;
+            gVrfOrch = nullptr;
+            gBufferOrch = nullptr;
+            gCrmOrch = nullptr;
+
+            Portal::DirectoryInternal::clear(gDirectory);
+            EXPECT_TRUE(Portal::DirectoryInternal::empty(gDirectory));
+        }
+
+        void initPorts()
+        {
+            auto portTable = Table(this->appDb.get(), APP_PORT_TABLE_NAME);
+
+            // Get SAI default ports to populate DB
+            auto ports = ut_helper::getInitialSaiPorts();
+
+            // Populate port table with SAI ports
+            for (const auto &cit : ports)
+            {
+                portTable.set(cit.first, cit.second);
+            }
+
+            // Set PortConfigDone
+            portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+
+            // Set PortInitDone
+            portTable.set("PortInitDone", { { "lanes", "0" } });
+            gPortsOrch->addExistingData(&portTable);
+            static_cast<Orch*>(gPortsOrch)->doTask();
+        }
+
+        void initDb()
+        {
+            this->appDb = std::make_shared<swss::DBConnector>("APPL_DB", 0);
+            this->configDb = std::make_shared<swss::DBConnector>("CONFIG_DB", 0);
+            this->stateDb = std::make_shared<swss::DBConnector>("STATE_DB", 0);
+            this->countersDb = make_shared<swss::DBConnector>("COUNTERS_DB", 0);
+            this->chassisAppDb = make_shared<swss::DBConnector>("CHASSIS_APP_DB", 0);
+            this->asicDb = make_shared<swss::DBConnector>("ASIC_DB", 0);
+        }
+
+        shared_ptr<swss::DBConnector> appDb;
+        shared_ptr<swss::DBConnector> configDb;
+        shared_ptr<swss::DBConnector> stateDb;
+        shared_ptr<swss::DBConnector> countersDb;
+        shared_ptr<swss::DBConnector> chassisAppDb;
+        shared_ptr<swss::DBConnector> asicDb;
+
+        std::vector<Orch*> resourcesList;
+    };
+
+    TEST_F(TwampOrchTest, TwampOrchTestCreateDeleteSenderPacketCountSingle)
+    {
+        string twampSessionName = "TEST_SENDER1";
+
+        MockTwampOrch twampOrch;
+
+        auto current_create_count = create_twamp_session_count;
+        auto current_remove_count = remove_twamp_session_count;
+        auto current_set_count = set_twamp_session_count;
+
+        // Create TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"mode",                "LIGHT"   },
+                        {"role",                "SENDER"  },
+                        {"src_ip",              "1.1.1.1" },
+                        {"src_udp_port",        "862"     },
+                        {"dst_ip",              "2.2.2.2" },
+                        {"dst_udp_port",        "863"     },
+                        {"packet_count",        "1000"    },
+                        {"tx_interval",         "10"      },
+                        {"timeout",             "10"      },
+                        {"statistics_interval", "20000"   },
+                        {"vrf_name",            "default" },
+                        {"dscp",                "0"       },
+                        {"ttl",                 "10"      },
+                        {"timestamp_format",    "ntp"     },
+                        {"padding_size",        "100"     },
+                        {"hw_lookup",           "true"    }
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "inactive");
+            ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        }
+
+        // Start TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "enabled"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "active");
+            ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+        }
+
+        // Process Notification
+        {
+            // mock a redis reply for notification
+            mockReply = (redisReply *)calloc(sizeof(redisReply), 1);
+            mockReply->type = REDIS_REPLY_ARRAY;
+            mockReply->elements = 3; // REDIS_PUBLISH_MESSAGE_ELEMNTS
+            mockReply->element = (redisReply **)calloc(sizeof(redisReply *), mockReply->elements);
+            mockReply->element[2] = (redisReply *)calloc(sizeof(redisReply), 1);
+            mockReply->element[2]->type = REDIS_REPLY_STRING;
+            sai_twamp_session_event_notification_data_t twamp_session_data;
+            sai_twamp_session_stat_t counters_ids[SAI_TWAMP_SESSION_STAT_DURATION_TS];
+            uint64_t counters[SAI_TWAMP_SESSION_STAT_DURATION_TS];
+            twamp_session_data.session_state = SAI_TWAMP_SESSION_STATE_INACTIVE;
+            twamp_session_data.twamp_session_id = (sai_object_id_t)0x1;
+            twamp_session_data.session_stats.index = 1;
+            twamp_session_data.session_stats.number_of_counters = 11;
+
+            counters_ids[0] = SAI_TWAMP_SESSION_STAT_RX_PACKETS;
+            counters_ids[1] = SAI_TWAMP_SESSION_STAT_RX_BYTE;
+            counters_ids[2] = SAI_TWAMP_SESSION_STAT_TX_PACKETS;
+            counters_ids[3] = SAI_TWAMP_SESSION_STAT_TX_BYTE;
+            counters_ids[4] = SAI_TWAMP_SESSION_STAT_DROP_PACKETS;
+            counters_ids[5] = SAI_TWAMP_SESSION_STAT_MAX_LATENCY;
+            counters_ids[6] = SAI_TWAMP_SESSION_STAT_MIN_LATENCY;
+            counters_ids[7] = SAI_TWAMP_SESSION_STAT_AVG_LATENCY;
+            counters_ids[8] = SAI_TWAMP_SESSION_STAT_MAX_JITTER;
+            counters_ids[9] = SAI_TWAMP_SESSION_STAT_MIN_JITTER;
+            counters_ids[10] = SAI_TWAMP_SESSION_STAT_AVG_JITTER;
+            counters[0] = 1000;
+            counters[1] = 100000;
+            counters[2] = 1000;
+            counters[3] = 100000;
+            counters[4] = 0;
+            counters[5] = 1987;
+            counters[6] = 1983;
+            counters[7] = 1984;
+            counters[8] = 2097;
+            counters[9] = 1896;
+            counters[10] = 1985;
+            twamp_session_data.session_stats.counters_ids = counters_ids;
+            twamp_session_data.session_stats.counters = counters;
+
+            std::string data = sai_serialize_twamp_session_event_ntf(1, &twamp_session_data);
+
+            std::vector<FieldValueTuple> notifyValues;
+            FieldValueTuple opdata("twamp_session_event", data);
+            notifyValues.push_back(opdata);
+            std::string msg = swss::JSon::buildJson(notifyValues);
+            mockReply->element[2]->str = (char*)calloc(1, msg.length() + 1);
+            memcpy(mockReply->element[2]->str, msg.c_str(), msg.length());
+
+            // trigger the notification
+            twampOrch.doTwampNotificationTask();
+            mockReply = nullptr;
+
+            TwampStatsTable twampStatistics = Portal::TwampOrchInternal::getTwampSessionStatistics(twampOrch.get());
+            ASSERT_TRUE(twampStatistics.find(twampSessionName) != twampStatistics.end());
+            ASSERT_EQ(twampStatistics[twampSessionName].rx_packets, 1000);
+            ASSERT_EQ(twampStatistics[twampSessionName].rx_bytes, 100000);
+            ASSERT_EQ(twampStatistics[twampSessionName].tx_packets, 1000);
+            ASSERT_EQ(twampStatistics[twampSessionName].tx_bytes, 100000);
+            ASSERT_EQ(twampStatistics[twampSessionName].drop_packets, 0);
+            ASSERT_EQ(twampStatistics[twampSessionName].max_latency, 1987);
+            ASSERT_EQ(twampStatistics[twampSessionName].min_latency, 1983);
+            ASSERT_EQ(twampStatistics[twampSessionName].avg_latency, 1984);
+            ASSERT_EQ(twampStatistics[twampSessionName].max_jitter, 2097);
+            ASSERT_EQ(twampStatistics[twampSessionName].min_jitter, 1896);
+            ASSERT_EQ(twampStatistics[twampSessionName].avg_jitter, 1985);
+        }
+
+        // Delete TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    DEL_COMMAND,
+                    { {} }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_FALSE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        }
+
+        // Make sure both create and set has been called
+        ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+    }
+
+    TEST_F(TwampOrchTest, TwampOrchTestCreateDeleteSenderPacketCountMulti)
+    {
+        string twampSessionName = "TEST_SENDER1";
+
+        MockTwampOrch twampOrch;
+
+        auto current_create_count = create_twamp_session_count;
+        auto current_remove_count = remove_twamp_session_count;
+        auto current_set_count = set_twamp_session_count;
+
+        // Create TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"mode",                "LIGHT"   },
+                        {"role",                "SENDER"  },
+                        {"src_ip",              "1.1.1.1" },
+                        {"src_udp_port",        "1862"    },
+                        {"dst_ip",              "2.2.2.2" },
+                        {"dst_udp_port",        "1863"    },
+                        {"packet_count",        "1000"    },
+                        {"tx_interval",         "10"      },
+                        {"timeout",             "10"      },
+                        {"statistics_interval", "11000"   }
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "inactive");
+            ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        }
+
+        // Start TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "enabled"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "active");
+            ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+        }
+
+        // Process Notification
+        {
+            sai_twamp_session_event_notification_data_t twamp_session_data;
+            sai_twamp_session_stat_t counters_ids[SAI_TWAMP_SESSION_STAT_DURATION_TS];
+            uint64_t counters[SAI_TWAMP_SESSION_STAT_DURATION_TS];
+            uint64_t latency_total = 0;
+            uint64_t jitter_total = 0;
+            twamp_session_data.twamp_session_id = (sai_object_id_t)0x1;
+            twamp_session_data.session_stats.number_of_counters = 11;
+            counters_ids[0] = SAI_TWAMP_SESSION_STAT_RX_PACKETS;
+            counters_ids[1] = SAI_TWAMP_SESSION_STAT_RX_BYTE;
+            counters_ids[2] = SAI_TWAMP_SESSION_STAT_TX_PACKETS;
+            counters_ids[3] = SAI_TWAMP_SESSION_STAT_TX_BYTE;
+            counters_ids[4] = SAI_TWAMP_SESSION_STAT_DROP_PACKETS;
+            counters_ids[5] = SAI_TWAMP_SESSION_STAT_MAX_LATENCY;
+            counters_ids[6] = SAI_TWAMP_SESSION_STAT_MIN_LATENCY;
+            counters_ids[7] = SAI_TWAMP_SESSION_STAT_AVG_LATENCY;
+            counters_ids[8] = SAI_TWAMP_SESSION_STAT_MAX_JITTER;
+            counters_ids[9] = SAI_TWAMP_SESSION_STAT_MIN_JITTER;
+            counters_ids[10] = SAI_TWAMP_SESSION_STAT_AVG_JITTER;
+            twamp_session_data.session_stats.counters_ids = counters_ids;
+            twamp_session_data.session_stats.counters = counters;
+            for (uint8_t i = 1; i <= 10; i++)
+            {
+                // mock a redis reply for notification
+                mockReply = (redisReply *)calloc(sizeof(redisReply), 1);
+                mockReply->type = REDIS_REPLY_ARRAY;
+                mockReply->elements = 3; // REDIS_PUBLISH_MESSAGE_ELEMNTS
+                mockReply->element = (redisReply **)calloc(sizeof(redisReply *), mockReply->elements);
+                mockReply->element[2] = (redisReply *)calloc(sizeof(redisReply), 1);
+                mockReply->element[2]->type = REDIS_REPLY_STRING;
+
+                twamp_session_data.session_state = (i<10) ? SAI_TWAMP_SESSION_STATE_ACTIVE : SAI_TWAMP_SESSION_STATE_INACTIVE;
+                twamp_session_data.session_stats.index = i;
+                counters[0] = 100;
+                counters[1] = 10000;
+                counters[2] = 100;
+                counters[3] = 10000;
+                counters[4] = 0;
+                counters[5] = 1000+i;
+                counters[6] = 1000+i;
+                counters[7] = 1000+i;
+                counters[8] = 1100+i;
+                counters[9] = 1100+i;
+                counters[10] = 1100+i;
+                latency_total += counters[7];
+                jitter_total += counters[10];
+
+                std::string data = sai_serialize_twamp_session_event_ntf(1, &twamp_session_data);
+
+                std::vector<FieldValueTuple> notifyValues;
+                FieldValueTuple opdata("twamp_session_event", data);
+                notifyValues.push_back(opdata);
+                std::string msg = swss::JSon::buildJson(notifyValues);
+                mockReply->element[2]->str = (char*)calloc(1, msg.length() + 1);
+                memcpy(mockReply->element[2]->str, msg.c_str(), msg.length());
+
+                // trigger the notification
+                twampOrch.doTwampNotificationTask();
+                mockReply = nullptr;
+
+                string session_status;
+                ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+                if (i<10)
+                {
+                    ASSERT_EQ(session_status, "active");
+                }
+                else
+                {
+                    ASSERT_EQ(session_status, "inactive");
+                }
+
+                TwampStatsTable twampStatistics = Portal::TwampOrchInternal::getTwampSessionStatistics(twampOrch.get());
+                ASSERT_TRUE(twampStatistics.find(twampSessionName) != twampStatistics.end());
+                ASSERT_EQ(twampStatistics[twampSessionName].rx_packets, 100*i);
+                ASSERT_EQ(twampStatistics[twampSessionName].rx_bytes, 10000*i);
+                ASSERT_EQ(twampStatistics[twampSessionName].tx_packets, 100*i);
+                ASSERT_EQ(twampStatistics[twampSessionName].tx_bytes, 10000*i);
+                ASSERT_EQ(twampStatistics[twampSessionName].drop_packets, 0);
+                ASSERT_EQ(twampStatistics[twampSessionName].max_latency, 1000+i);
+                ASSERT_EQ(twampStatistics[twampSessionName].min_latency, 1000+1);
+                ASSERT_EQ(twampStatistics[twampSessionName].avg_latency, latency_total/i);
+                ASSERT_EQ(twampStatistics[twampSessionName].max_jitter, 1100+i);
+                ASSERT_EQ(twampStatistics[twampSessionName].min_jitter, 1100+1);
+                ASSERT_EQ(twampStatistics[twampSessionName].avg_jitter, jitter_total/i);
+            }
+        }
+
+        // Delete TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    DEL_COMMAND,
+                    { {} }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_FALSE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        }
+
+        // Make sure both create and set has been called
+        ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+    }
+
+    TEST_F(TwampOrchTest, TwampOrchTestCreateDeleteSenderContinuousSingle)
+    {
+        string twampSessionName = "TEST_SENDER1";
+
+        MockTwampOrch twampOrch;
+
+        auto current_create_count = create_twamp_session_count;
+        auto current_remove_count = remove_twamp_session_count;
+        auto current_set_count = set_twamp_session_count;
+
+        // Create TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"mode",                "LIGHT"   },
+                        {"role",                "SENDER"  },
+                        {"src_ip",              "1.1.1.1" },
+                        {"src_udp_port",        "862"     },
+                        {"dst_ip",              "2.2.2.2" },
+                        {"dst_udp_port",        "863"     },
+                        {"monitor_time",        "60"      },
+                        {"tx_interval",         "100"     },
+                        {"timeout",             "10"      },
+                        {"statistics_interval", "60000"   },
+                        {"vrf_name",            "default" },
+                        {"dscp",                "0"       },
+                        {"ttl",                 "10"      },
+                        {"timestamp_format",    "ntp"     },
+                        {"padding_size",        "100"     },
+                        {"hw_lookup",           "true"    }
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "inactive");
+            ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        }
+
+        // Start TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "enabled"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "active");
+            ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+        }
+
+        // Delete TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    DEL_COMMAND,
+                    { {} }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_FALSE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        }
+
+        // Make sure both create and set has been called
+        ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+    }
+
+    TEST_F(TwampOrchTest, TwampOrchTestCreateDeleteSenderContinuousMulti)
+    {
+        string twampSessionName = "TEST_SENDER1";
+
+        MockTwampOrch twampOrch;
+
+        auto current_create_count = create_twamp_session_count;
+        auto current_remove_count = remove_twamp_session_count;
+        auto current_set_count = set_twamp_session_count;
+
+        // Create TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"mode",                "LIGHT"   },
+                        {"role",                "SENDER"  },
+                        {"src_ip",              "1.1.1.1" },
+                        {"src_udp_port",        "1862"    },
+                        {"dst_ip",              "2.2.2.2" },
+                        {"dst_udp_port",        "1863"    },
+                        {"monitor_time",        "0"       },
+                        {"tx_interval",         "100"     },
+                        {"timeout",             "10"      },
+                        {"statistics_interval", "20000"   },
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "inactive");
+            ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        }
+
+        // Start TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "enabled"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "active");
+            ASSERT_EQ(current_set_count + 1, set_twamp_session_count);
+        }
+
+        // Stop TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"admin_state", "disabled"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "inactive");
+            ASSERT_EQ(current_set_count + 2, set_twamp_session_count);
+        }
+
+        // Delete TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    DEL_COMMAND,
+                    { {} }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_FALSE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        }
+
+        // Make sure both create and set has been called
+        ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        ASSERT_EQ(current_set_count + 2, set_twamp_session_count);
+    }
+
+    TEST_F(TwampOrchTest, TwampOrchTestCreateDeleteReflector)
+    {
+        string twampSessionName = "TEST_SENDER1";
+
+        MockTwampOrch twampOrch;
+
+        auto current_create_count = create_twamp_session_count;
+        auto current_remove_count = remove_twamp_session_count;
+        auto current_set_count = set_twamp_session_count;
+
+        // Create TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    SET_COMMAND,
+                    {
+                        {"mode", "LIGHT"},
+                        {"role", "REFLECTOR"},
+                        {"src_ip", "1.1.1.1"},
+                        {"src_udp_port", "862"},
+                        {"dst_ip", "2.2.2.2"},
+                        {"dst_udp_port", "863"}
+                    }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_TRUE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(session_status, "active");
+            ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        }
+
+        // Delete TWAMP Light session
+        {
+            std::deque<KeyOpFieldsValuesTuple> tableKofvt;
+            tableKofvt.push_back(
+                {
+                    twampSessionName,
+                    DEL_COMMAND,
+                    { {} }
+                }
+            );
+
+            twampOrch.doTwampTableTask(tableKofvt);
+
+            string session_status;
+            ASSERT_FALSE(twampOrch.get().getSessionStatus(twampSessionName, session_status));
+            ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        }
+
+        // Make sure both create and set has been called
+        ASSERT_EQ(current_create_count + 1, create_twamp_session_count);
+        ASSERT_EQ(current_remove_count + 1, remove_twamp_session_count);
+        ASSERT_EQ(current_set_count, set_twamp_session_count);
+    }
+}

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -89,6 +89,7 @@ namespace ut_helper
         sai_api_query(SAI_API_MPLS, (void**)&sai_mpls_api);
         sai_api_query(SAI_API_COUNTER, (void**)&sai_counter_api);
         sai_api_query(SAI_API_FDB, (void**)&sai_fdb_api);
+        sai_api_query(SAI_API_TWAMP, (void**)&sai_twamp_api);
 
         return SAI_STATUS_SUCCESS;
     }
@@ -118,6 +119,7 @@ namespace ut_helper
         sai_buffer_api = nullptr;
         sai_queue_api = nullptr;
         sai_counter_api = nullptr;
+        sai_twamp_api = nullptr;
 
         return SAI_STATUS_SUCCESS;
     }

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -243,29 +243,6 @@ class TestAcl:
         dvs_acl.verify_acl_rule_status(MIRROR_TABLE_NAME, MIRROR_RULE_NAME, None)
         dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInPortsL3(self, dvs_acl, l3_acl_table):
-        """
-        Verify IN_PORTS matches on ACL rule.
-        Using L3 table type for IN_PORTS matches.
-        """
-        config_qualifiers = {
-            "IN_PORTS": "Ethernet8,Ethernet12",
-        }
-
-        expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
-        }
-
-        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
-        # Verify status is written into STATE_DB
-        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, "Active")
-        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
-
-        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
-        # Verify the STATE_DB entry is removed
-        dvs_acl.verify_acl_rule_status(L3_TABLE_NAME, L3_RULE_NAME, None)
-        dvs_acl.verify_no_acl_rules()
-
     def test_AclRuleOutPorts(self, dvs_acl, mclag_acl_table):
         """
         Verify OUT_PORTS matches on ACL rule.
@@ -557,25 +534,6 @@ class TestAcl:
         config_qualifiers = {"VLAN_ID": "100"}
         expected_sai_qualifiers = {
             "SAI_ACL_ENTRY_ATTR_FIELD_OUTER_VLAN_ID": dvs_acl.get_simple_qualifier_comparator("100&mask:0xfff")
-        }
-
-        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
-        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
-        # Verify status is written into STATE_DB
-        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, "Active")
-
-        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
-        # Verify the STATE_DB entry is removed
-        dvs_acl.verify_acl_rule_status(L3V6_TABLE_NAME, L3V6_RULE_NAME, None)
-        dvs_acl.verify_no_acl_rules()
-
-    def test_v6AclRuleInPorts(self, dvs_acl, l3v6_acl_table):
-        config_qualifiers = {
-            "IN_PORTS": "Ethernet8,Ethernet12",
-        }
-
-        expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)

--- a/tests/test_twamp.py
+++ b/tests/test_twamp.py
@@ -1,0 +1,182 @@
+# This test suite covers the functionality of twamp light feature in SwSS
+import pytest
+import time
+
+@pytest.mark.usefixtures("testlog")
+@pytest.mark.usefixtures('dvs_twamp_manager')
+class TestTwampLight(object):
+
+    def check_syslog(self, dvs, marker, log, expected_cnt):
+        (ec, out) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \'%s\' | wc -l" % (marker, log)])
+        assert out.strip() == str(expected_cnt)
+
+    def test_SenderPacketCountSingle(self, dvs, testlog):
+        """
+        This test covers the TWAMP Light session creation and removal operations
+        Operation flow:
+        1. Create twamp-light session-sender using once packet-count
+           The session remains inactive
+        2. Start twamp-light session
+           The session becomes active
+        3. Remove twamp-light session
+        """
+
+        session = "TEST_SENDER1"
+        src_ip = "1.1.1.1"
+        src_udp_port = "862"
+        dst_ip = "2.2.2.2"
+        dst_udp_port = "863"
+        packet_count = "1000"
+        tx_interval = "10"
+        timeout = "10"
+        stats_interval = "20000"
+
+        marker = dvs.add_log_marker()
+
+        # create twamp-light session
+        self.dvs_twamp.create_twamp_light_session_sender_packet_count(session, src_ip, src_udp_port, dst_ip, dst_udp_port, packet_count, tx_interval, timeout)
+
+        # start twamp-light session
+        self.dvs_twamp.start_twamp_light_sender(session)
+
+        # wait for sending TWAMP-test done
+        time.sleep(12)
+
+        # remove twamp-light session
+        self.dvs_twamp.remove_twamp_light_session(session)
+        self.dvs_twamp.verify_no_session()
+
+    def test_SenderPacketCountMulti(self, dvs, testlog):
+        """
+        This test covers the TWAMP Light Sender session creation and removal operations
+        Operation flow:
+        1. Create twamp-light session-sender using multi packet-count
+           The session remains inactive
+        2. Start twamp-light session
+           The session becomes active
+        3. Remove twamp-light session
+        """
+
+        session = "TEST_SENDER1"
+        src_ip = "1.2.3.4"
+        src_udp_port = "862"
+        dst_ip = "5.6.7.8"
+        dst_udp_port = "863"
+        packet_count = "1000"
+        tx_interval = "10"
+        timeout = "10"
+        stats_interval = "11000"
+
+        marker = dvs.add_log_marker()
+
+        # create twamp-light session
+        self.dvs_twamp.create_twamp_light_session_sender_packet_count(session, src_ip, src_udp_port, dst_ip, dst_udp_port, packet_count, tx_interval, timeout, stats_interval)
+
+        # start twamp-light session
+        self.dvs_twamp.start_twamp_light_sender(session)
+
+        # wait for sending TWAMP-test done
+        time.sleep(120)
+
+        # remove twamp-light session
+        self.dvs_twamp.remove_twamp_light_session(session)
+        self.dvs_twamp.verify_no_session()
+
+    def test_SenderContinuousSingle(self, dvs, testlog):
+        """
+        This test covers the TWAMP Light Sender session creation and removal operations
+        Operation flow:
+        1. Create twamp-light session-sender using once continuous
+           The session remains inactive
+        2. Start twamp-light session
+           The session becomes active
+        3. Remove twamp-light session
+        """
+
+        session = "TEST_SENDER2"
+        src_ip = "11.11.11.11"
+        src_udp_port = "862"
+        dst_ip = "12.12.12.12"
+        dst_udp_port = "863"
+        monitor_time = "60"
+        tx_interval = "100"
+        timeout = "10"
+        stats_interval = "60000"
+
+        marker = dvs.add_log_marker()
+
+        # create twamp-light session
+        self.dvs_twamp.create_twamp_light_session_sender_continuous(session, src_ip, src_udp_port, dst_ip, dst_udp_port, monitor_time, tx_interval, timeout)
+
+        # start twamp-light session
+        self.dvs_twamp.start_twamp_light_sender(session)
+        # wait for sending TWAMP-test done
+        time.sleep(60)
+
+        # remove twamp-light session
+        self.dvs_twamp.remove_twamp_light_session(session)
+        self.dvs_twamp.verify_no_session()
+
+    def test_SenderContinuousMulti(self, dvs, testlog):
+        """
+        This test covers the continuous TWAMP Light Sender session creation and removal operations
+        Operation flow:
+        1. Create twamp-light session-sender using multi continuous
+           The session remains inactive
+        2. Start twamp-light session
+           The session becomes active
+        3. Remove twamp-light session
+        """
+
+        session = "TEST_SENDER2"
+        src_ip = "11.12.13.14"
+        src_udp_port = "862"
+        dst_ip = "15.16.17.18"
+        dst_udp_port = "863"
+        monitor_time = "60"
+        tx_interval = "100"
+        timeout = "10"
+        stats_interval = "20000"
+
+        marker = dvs.add_log_marker()
+
+        # create twamp-light session
+        self.dvs_twamp.create_twamp_light_session_sender_continuous(session, src_ip, src_udp_port, dst_ip, dst_udp_port, monitor_time, tx_interval, timeout, stats_interval)
+
+        # start twamp-light session
+        self.dvs_twamp.start_twamp_light_sender(session)
+
+        # wait for sending TWAMP-test done
+        time.sleep(60)
+
+        # remove twamp-light session
+        self.dvs_twamp.remove_twamp_light_session(session)
+        self.dvs_twamp.verify_no_session()
+
+    def test_Reflector(self, dvs, testlog):
+        """
+        This test covers the TWAMP Light Reflector session creation and removal operations
+        Operation flow:
+        1. Create twamp-light session-reflector
+        2. Remove twamp-light session
+        """
+
+        session = "TEST_REFLECTOR1"
+        src_ip = "22.1.1.1"
+        src_udp_port = "862"
+        dst_ip = "22.1.1.2"
+        dst_udp_port = "863"
+
+        marker = dvs.add_log_marker()
+
+        # create twamp-light session
+        self.dvs_twamp.create_twamp_light_session_reflector(session, src_ip, src_udp_port, dst_ip, dst_udp_port)
+
+        # remove twamp-light session
+        self.dvs_twamp.remove_twamp_light_session(session)
+        self.dvs_twamp.verify_no_session()
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -5,6 +5,8 @@ import time
 import pytest
 import buffer_model
 
+DVS_ENV = ["ASIC_VENDOR=vs"]
+
 class TestVirtualChassis(object):
 
     def set_lag_id_boundaries(self, vct):
@@ -138,7 +140,6 @@ class TestVirtualChassis(object):
                 spcfg = ast.literal_eval(value)
                 assert spcfg['count'] == sp_count, "Number of systems ports configured is invalid"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_app_db_sync(self, vct):
         """Test chassis app db syncing.
 
@@ -159,7 +160,6 @@ class TestVirtualChassis(object):
                 keys = chassis_app_db.get_keys("SYSTEM_INTERFACE")
                 assert len(keys), "No chassis app db syncing is done"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_interface(self, vct):
         """Test RIF record creation in ASIC_DB for remote interfaces.
 
@@ -216,7 +216,6 @@ class TestVirtualChassis(object):
                     # Remote system ports's switch id should not match local switch id
                     assert spcfginfo["attached_switch_id"] != lc_switch_id, "RIF system port with wrong switch_id"
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_neigh(self, vct):
         """Test neigh record create/delete and syncing to chassis app db.
 
@@ -312,8 +311,8 @@ class TestVirtualChassis(object):
                     test_sysneigh = ""
                     for sysnk in sysneighkeys:
                         sysnk_tok = sysnk.split("|")
-                        assert len(sysnk_tok) == 3, "Invalid system neigh key in chassis app db"
-                        if sysnk_tok[2] == test_neigh_ip:
+                        assert len(sysnk_tok) == 4, "Invalid system neigh key in chassis app db"
+                        if sysnk_tok[3] == test_neigh_ip:
                             test_sysneigh = sysnk
                             break
 
@@ -372,7 +371,7 @@ class TestVirtualChassis(object):
                         # Check for kernel entries
 
                         _, output = dvs.runcmd("ip neigh show")
-                        assert f"{test_neigh_ip} dev {inband_port}" in output, "Kernel neigh not found for remote neighbor"
+                        assert f"{test_neigh_ip} dev {inband_port} lladdr {mac_address}" in output, "Kernel neigh not found for remote neighbor"
 
                         _, output = dvs.runcmd("ip route show")
                         assert f"{test_neigh_ip} dev {inband_port} scope link" in output, "Kernel route not found for remote neighbor"
@@ -487,7 +486,6 @@ class TestVirtualChassis(object):
         # Cleanup inband if configuration
         self.del_inbandif_port(vct, inband_port)
         
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag(self, vct):
         """Test PortChannel in VOQ based chassis systems.
         
@@ -624,7 +622,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag_id_allocator_table_full(self, vct):
         """Test lag id allocator table full.
         
@@ -702,7 +699,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_chassis_system_lag_id_allocator_del_id(self, vct):
         """Test lag id allocator's release id and re-use id processing.
         


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updating oper FEC status in state_db after warm-reboot as part of refresh port status call

**Why I did it**
Oper FEC was not properly displayed after warm-boot. Hence fixing the issue

**How I verified it**
Manual verification as well as adding UT.

**Details if related**
