### PR TITLE
Moving speed setting below interface type setting

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4169,72 +4169,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     SWSS_LOG_NOTICE("Set port %s link event damping config successfully", p.m_alias.c_str());
                 }
 
-                if (pCfg.speed.is_set)
-                {
-                    if (p.m_speed != pCfg.speed.value)
-                    {
-                        if (!isSpeedSupported(p.m_alias, p.m_port_id, pCfg.speed.value))
-                        {
-                            SWSS_LOG_ERROR(
-                                "Unsupported port %s speed %u",
-                                p.m_alias.c_str(), pCfg.speed.value
-                            );
-                            // Speed not supported, dont retry
-                            it = taskMap.erase(it);
-                            continue;
-                        }
-
-                        // for backward compatible, if autoneg is off, toggle admin status
-                        if (p.m_admin_state_up && !p.m_autoneg)
-                        {
-                            /* Bring port down before applying speed */
-                            if (!setPortAdminStatus(p, false))
-                            {
-                                SWSS_LOG_ERROR(
-                                    "Failed to set port %s admin status DOWN to set speed",
-                                    p.m_alias.c_str()
-                                );
-                                it++;
-                                continue;
-                            }
-
-                            p.m_admin_state_up = false;
-                            m_portList[p.m_alias] = p;
-                        }
-
-                        auto status = setPortSpeed(p, pCfg.speed.value);
-                        if (status != task_success)
-                        {
-                            SWSS_LOG_ERROR(
-                                "Failed to set port %s speed from %u to %u",
-                                p.m_alias.c_str(), p.m_speed, pCfg.speed.value
-                            );
-                            if (status == task_need_retry)
-                            {
-                                it++;
-                            }
-                            else
-                            {
-                                it = taskMap.erase(it);
-                            }
-                            continue;
-                        }
-
-                        p.m_speed = pCfg.speed.value;
-                        m_portList[p.m_alias] = p;
-
-                        SWSS_LOG_NOTICE(
-                            "Set port %s speed to %u",
-                            p.m_alias.c_str(), pCfg.speed.value
-                        );
-                    }
-                    else
-                    {
-                        /* Always update Gearbox speed on Gearbox ports */
-                        setGearboxPortsAttr(p, SAI_PORT_ATTR_SPEED, &pCfg.speed.value);
-                    }
-                }
-
                 if (pCfg.adv_speeds.is_set)
                 {
                     if (!p.m_adv_speed_cfg || p.m_adv_speeds != pCfg.adv_speeds.value)
@@ -4384,6 +4318,72 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             "Set port %s advertised interface type to %s",
                             p.m_alias.c_str(), m_portHlpr.getAdvInterfaceTypesStr(pCfg).c_str()
                         );
+                    }
+                }
+
+                if (pCfg.speed.is_set)
+                {
+                    if (p.m_speed != pCfg.speed.value)
+                    {
+                        if (!isSpeedSupported(p.m_alias, p.m_port_id, pCfg.speed.value))
+                        {
+                            SWSS_LOG_ERROR(
+                                "Unsupported port %s speed %u",
+                                p.m_alias.c_str(), pCfg.speed.value
+                            );
+                            // Speed not supported, dont retry
+                            it = taskMap.erase(it);
+                            continue;
+                        }
+
+                        // for backward compatible, if autoneg is off, toggle admin status
+                        if (p.m_admin_state_up && !p.m_autoneg)
+                        {
+                            /* Bring port down before applying speed */
+                            if (!setPortAdminStatus(p, false))
+                            {
+                                SWSS_LOG_ERROR(
+                                    "Failed to set port %s admin status DOWN to set speed",
+                                    p.m_alias.c_str()
+                                );
+                                it++;
+                                continue;
+                            }
+
+                            p.m_admin_state_up = false;
+                            m_portList[p.m_alias] = p;
+                        }
+
+                        auto status = setPortSpeed(p, pCfg.speed.value);
+                        if (status != task_success)
+                        {
+                            SWSS_LOG_ERROR(
+                                "Failed to set port %s speed from %u to %u",
+                                p.m_alias.c_str(), p.m_speed, pCfg.speed.value
+                            );
+                            if (status == task_need_retry)
+                            {
+                                it++;
+                            }
+                            else
+                            {
+                                it = taskMap.erase(it);
+                            }
+                            continue;
+                        }
+
+                        p.m_speed = pCfg.speed.value;
+                        m_portList[p.m_alias] = p;
+
+                        SWSS_LOG_NOTICE(
+                            "Set port %s speed to %u",
+                            p.m_alias.c_str(), pCfg.speed.value
+                        );
+                    }
+                    else
+                    {
+                        /* Always update Gearbox speed on Gearbox ports */
+                        setGearboxPortsAttr(p, SAI_PORT_ATTR_SPEED, &pCfg.speed.value);
                     }
                 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Moved speed setting below interface type setting in the processing order. Sometimes the interface type settings are required to set proper speed and to avoid ambiguity (e.g. 100G can be set on 2 lanes in PAM4 case or 4 lanes in case of NRZ case which is decided by interface type).

When user configures speed and interface type commands next to next, it may be combined as a single update due to optimization in orchagent and with the current order it may result in speed getting processed before interface type. 

User commands
```
2024 Aug 29 00:06:16.683596 mtvr-hippo-01 NOTICE sudo:    admin : TTY=pts/1 ; PWD=/home/admin ; USER=root ; COMMAND=/usr/local/bin/config interface type Ethernet336 none
2024 Aug 29 00:06:18.295811 mtvr-hippo-01 NOTICE sudo:    admin : TTY=pts/1 ; PWD=/home/admin ; USER=root ; COMMAND=/usr/local/bin/config interface speed Ethernet336 25000
```

SWSS record

```
2024-08-28.21:06:19.117532|PORT_TABLE:Ethernet336|SET|alias:etp43|index:43|lanes:336,337,338,339,340,341,342,343|speed:25000|autoneg:off|interface_type:none|adv_speeds:400000|adv_interface_types:CR8|fec:rs|mtu:9100|admin_status:down

```

**Why I did it**
Moved processing of speed setting after interface type in order to avoid any error in programming SAI.

**How I verified it**
Existing tests should verify the current functionality. Ordering cannot be tested with the current vs test infrastructure.

**Details if related**
