### PR TITLE
Fixing fpmsyncd to handle scaled nexthops

### DIFF
--- a/fpmsyncd/fpm/fpm.h
+++ b/fpmsyncd/fpm/fpm.h
@@ -92,7 +92,7 @@
 /*
  * Largest message that can be sent to or received from the FPM.
  */
-#define FPM_MAX_MSG_LEN 4096
+#define FPM_MAX_MSG_LEN 16384
 
 /*
  * Header that precedes each fpm message to/from the FPM.

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -77,6 +77,7 @@ int main(int argc, char **argv)
     NetDispatcher::getInstance().registerMessageHandler(RTM_DELLINK, &sync);
 
     rtnl_route_read_protocol_names(DefaultRtProtoPath);
+    nlmsg_set_default_size(FPM_MAX_MSG_LEN);
 
     std::string suppressionEnabledStr;
     deviceMetadataTable.hget("localhost", "suppress-fib-pending", suppressionEnabledStr);

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1354,12 +1354,23 @@ bool RouteSync::sendOffloadReply(struct nlmsghdr* hdr)
 bool RouteSync::sendOffloadReply(struct rtnl_route* route_obj)
 {
     SWSS_LOG_ENTER();
+    int ret = 0;
 
     nl_msg* msg{};
-    rtnl_route_build_add_request(route_obj, NLM_F_CREATE, &msg);
+    ret = rtnl_route_build_add_request(route_obj, NLM_F_CREATE, &msg);
 
+    if (ret !=0)
+    {
+        SWSS_LOG_ERROR("Route build add returned %d", ret);
+        return false;
+    }
     auto nlMsg = makeUniqueWithDestructor(msg, nlmsg_free);
 
+    if (nlMsg.get() == NULL)
+    {
+        SWSS_LOG_ERROR("Error in allocation for sending offload reply");
+        return false;
+    }
     return sendOffloadReply(nlmsg_hdr(nlMsg.get()));
 }
 

--- a/tests/mock_tests/fake_netlink.cpp
+++ b/tests/mock_tests/fake_netlink.cpp
@@ -1,5 +1,6 @@
 #include <swss/linkcache.h>
 #include <swss/logger.h>
+#include <netlink/route/route.h>
 
 static rtnl_link* g_fakeLink = [](){
     auto fakeLink = rtnl_link_alloc();
@@ -7,6 +8,8 @@ static rtnl_link* g_fakeLink = [](){
     return fakeLink;
 }();
 
+extern int rt_build_ret;
+extern bool nlmsg_alloc_ret;
 extern "C"
 {
 
@@ -15,4 +18,34 @@ struct rtnl_link* rtnl_link_get_by_name(struct nl_cache *cache, const char *name
     return g_fakeLink;
 }
 
+static int build_route_msg(struct rtnl_route *tmpl, int cmd, int flags,
+			   struct nl_msg **result)
+{
+	struct nl_msg *msg;
+	int err;
+	if (!(msg = nlmsg_alloc_simple(cmd, flags)))
+		return -NLE_NOMEM;
+	if ((err = rtnl_route_build_msg(msg, tmpl)) < 0) {
+		nlmsg_free(msg);
+		return err;
+	}
+	*result = msg;
+	return 0;
+}
+
+int rtnl_route_build_add_request(struct rtnl_route *tmpl, int flags,
+				 struct nl_msg **result)
+{
+    if (rt_build_ret != 0)
+    {
+        return rt_build_ret;
+    }
+    else if (!nlmsg_alloc_ret)
+    {
+	*result = NULL;
+        return 0;
+    }
+    return build_route_msg(tmpl, RTM_NEWROUTE, NLM_F_CREATE | flags,
+                           result);
+}
 }

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -12,6 +12,8 @@ using namespace swss;
 
 using ::testing::_;
 
+int rt_build_ret = 0;
+bool nlmsg_alloc_ret = true;
 class MockRouteSync : public RouteSync
 {
 public:
@@ -230,5 +232,20 @@ TEST_F(FpmSyncdResponseTest, testEvpn)
     app_route_table.get(keys[0], fieldValues);
     auto value = swss::fvsGetValue(fieldValues, "protocol", true);
     ASSERT_EQ(value.get(), "0xc8");
+
+}
+
+TEST_F(FpmSyncdResponseTest, testSendOffloadReply)
+{
+
+    rt_build_ret = 1;
+    rtnl_route* routeObject{};
+
+
+    ASSERT_EQ(m_routeSync.sendOffloadReply(routeObject), false);
+    rt_build_ret = 0;
+    nlmsg_alloc_ret = false;
+    ASSERT_EQ(m_routeSync.sendOffloadReply(routeObject), false);
+    nlmsg_alloc_ret = true;
 
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixing fpmsyncd to handle scaled nexthops(e.g. 256 nexthops). In this scenario the max message len is increased to accommodate zebra message size.  In addition initialized nlmsg_set_default_size to allow netlink to process the increased message size as well without which libnl would crash.

**Why I did it**
To support increased nexthops.

**How I verified it**
Running test with 256 nexthops

**Details if related**
