### PR TITLE
[fpmsyncd]Fixing blackhole route to publish protocol field to APPL_DB

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1636,6 +1636,9 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
     {
         sendOffloadReply(route_obj);
     }
+    auto proto_num = rtnl_route_get_protocol(route_obj);
+    auto proto_str = getProtocolString(proto_num);
+    FieldValueTuple proto("protocol", proto_str);
 
     switch (rtnl_route_get_type(route_obj))
     {
@@ -1644,6 +1647,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             vector<FieldValueTuple> fvVector;
             FieldValueTuple fv("blackhole", "true");
             fvVector.push_back(fv);
+            fvVector.push_back(proto);
             m_routeTable.set(destipprefix, fvVector);
             return;
         }
@@ -1699,9 +1703,6 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             installNextHopGroup(nhg_id);
         }
 
-        auto proto_num = rtnl_route_get_protocol(route_obj);
-        auto proto_str = getProtocolString(proto_num);
-        FieldValueTuple proto("protocol", proto_str);
         fvVector.push_back(proto);
 
     }
@@ -1766,11 +1767,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
             }
         }
 
-        auto proto_num = rtnl_route_get_protocol(route_obj);
-        auto proto_str = getProtocolString(proto_num);
 
-
-        FieldValueTuple proto("protocol", proto_str);
         FieldValueTuple gw("nexthop", gw_list);
         FieldValueTuple intf("ifname", intf_list);
 
@@ -1983,6 +1980,10 @@ void RouteSync::onLabelRouteMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
+    auto proto_num = rtnl_route_get_protocol(route_obj);
+    auto proto_str = getProtocolString(proto_num);
+    FieldValueTuple proto("protocol", proto_str);
+
     switch (rtnl_route_get_type(route_obj))
     {
         case RTN_BLACKHOLE:
@@ -1990,6 +1991,7 @@ void RouteSync::onLabelRouteMsg(int nlmsg_type, struct nl_object *obj)
             vector<FieldValueTuple> fvVector;
             FieldValueTuple fv("blackhole", "true");
             fvVector.push_back(fv);
+            fvVector.push_back(proto);
             m_label_routeTable.set(destaddr, fvVector);
             return;
         }

--- a/tests/mock_tests/fpmsyncd/test_routesync.cpp
+++ b/tests/mock_tests/fpmsyncd/test_routesync.cpp
@@ -904,3 +904,44 @@ TEST_F(FpmSyncdResponseTest, TestRouteMsgWithNHG)
 
     rtnl_route_put(test_route);
 }
+
+TEST_F(FpmSyncdResponseTest, TestBlackholeRoute)
+{
+    Table route_table(m_db.get(), APP_ROUTE_TABLE_NAME);
+    auto createRoute = [](const char* prefix, uint8_t prefixlen) -> rtnl_route* {
+        rtnl_route* route = rtnl_route_alloc();
+        nl_addr* dst_addr;
+        nl_addr_parse(prefix, AF_INET, &dst_addr);
+        rtnl_route_set_dst(route, dst_addr);
+        rtnl_route_set_type(route, RTN_BLACKHOLE);
+        rtnl_route_set_protocol(route, RTPROT_STATIC);
+        rtnl_route_set_family(route, AF_INET);
+        rtnl_route_set_scope(route, RT_SCOPE_UNIVERSE);
+        rtnl_route_set_table(route, RT_TABLE_MAIN);
+        nl_addr_put(dst_addr);
+        return route;
+    };
+
+    // create a route
+    const char* test_destipprefix = "10.1.1.0";
+    rtnl_route* test_route = createRoute(test_destipprefix, 24);
+
+    {
+
+        m_mockRouteSync.onRouteMsg(RTM_NEWROUTE, (nl_object*)test_route, nullptr);
+
+        // verify the blackhole route has protocol programmed
+        vector<FieldValueTuple> fvs;
+        EXPECT_TRUE(route_table.get(test_destipprefix, fvs));
+
+        bool proto_found = false;
+        for (const auto& fv : fvs) {
+            if (fvField(fv) == "protocol") {
+                proto_found = true;
+                EXPECT_EQ(fvValue(fv), "static");
+            }
+        }
+        EXPECT_TRUE(proto_found);
+    }
+
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixing blackhole route flow to publish protocol field to APPL_DB. When suppress fib pending is enabled, the protocol field is mandatory and not setting it results in fpmsyncd exiting in the route response path. 

**Why I did it**
To fix fpmsyncd from exiting on programming blackhole routes with suppress fib pending enabled.

**How I verified it**
Added UT to verify. Manually added blackhole route and verified as well.

**Details if related**
